### PR TITLE
For coronagraph masks, add reference information on alignment per Lyot mask, and also MIRI FQPM central wavelengths

### DIFF
--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -416,10 +416,16 @@ INSTRUMENT_IFU_BROADENING_PARAMETERS = {
 
 # Alignment information about instrument internal pupil masks (
 INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS = {
-    'NIRCam_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_MASKRND_SW': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_MASKRND_LW': {'pupil_shift_x': -0.012, 'pupil_shift_y': -0.023, 'pupil_rotation': -0.60},  # from K. Lawson, fits to ERS progid 1386 data
+    'NIRCam_SWA_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_SWA_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_SWA_MASK210R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_SWA_MASK335R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_SWA_MASK430R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_LWA_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_LWA_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_LWA_MASK210R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_LWA_MASK335R': {'pupil_shift_x': -0.012, 'pupil_shift_y': -0.023, 'pupil_rotation': -0.60},  # from K. Lawson, fits to ERS progid 1386 data
+    'NIRCam_LWA_MASK430R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
     'MIRI_MASKFQPM_F1065C': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
     'MIRI_MASKFQPM_F11140': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
     'MIRI_MASKFQPM_F1550C': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},

--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -437,6 +437,14 @@ INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS = {
     'MIRI_MASKLYOT': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
 }
 
+# The coronagraph mask central wavelengths as-built may not precisely match the nominal design wavelengths.
+# In particular there's a measured offset for the F1140C mask
+MIRI_CORONAGRAPH_CENTRAL_WAVELENGTHS = {
+        'FQPM1065': 10.65e-6,
+        'FQPM1140': 11.40e-6*1.03,   # priv. comm. A. Boccaletti and P. Baudoz
+        'FQPM1550': 15.50e-6,
+        }
+
 # Information about the effects on WFE of the IEC thermal variations
 #
 # Table of value for IEC telemetry to WFE model. Coefficients from model fit by Randal Telfer

--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -418,13 +418,13 @@ INSTRUMENT_IFU_BROADENING_PARAMETERS = {
 INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS = {
     'NIRCam_SWA_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
     'NIRCam_SWA_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_SWA_MASK210R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_SWA_MASK335R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_SWA_MASK210R': {'pupil_shift_x': -0.0045, 'pupil_shift_y': -0.0019, 'pupil_rotation': -0.338},  # From M. Perrin, fits to ref star from pid 1411,
+    'NIRCam_SWA_MASK335R': {'pupil_shift_x': 0.0090, 'pupil_shift_y': 0.0013, 'pupil_rotation': -0.083}, # from K. Lawson, fits to ref star from pid 4050
     'NIRCam_SWA_MASK430R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
     'NIRCam_LWA_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
     'NIRCam_LWA_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
     'NIRCam_LWA_MASK210R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_LWA_MASK335R': {'pupil_shift_x': -0.012, 'pupil_shift_y': -0.023, 'pupil_rotation': -0.60},  # from K. Lawson, fits to ERS progid 1386 data
+    'NIRCam_LWA_MASK335R': {'pupil_shift_x': -0.0134, 'pupil_shift_y': -0.0076, 'pupil_rotation': -0.56},  # from K. Lawson, fits to ERS progid 1386 data
     'NIRCam_LWA_MASK430R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
     # Draft placeholder values for MIRI based on Wright, Sabatke, & Telfer 2023.
     #    (∆V2, ∆V3) = (0.68%, -1.1%)

--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -414,6 +414,18 @@ INSTRUMENT_IFU_BROADENING_PARAMETERS = {
     'MIRI': {'sigma': 0.05},
 }
 
+# Alignment information about instrument internal pupil masks (
+INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS = {
+    'NIRCam_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_MASKRND_SW': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCam_MASKRND_LW': {'pupil_shift_x': -0.012, 'pupil_shift_y': -0.023, 'pupil_rotation': -0.60},  # from K. Lawson, fits to ERS progid 1386 data
+    'MIRI_MASKFQPM_F1065C': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'MIRI_MASKFQPM_F11140': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'MIRI_MASKFQPM_F1550C': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'MIRI_MASKLYOT': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+}
+
 # Information about the effects on WFE of the IEC thermal variations
 #
 # Table of value for IEC telemetry to WFE model. Coefficients from model fit by Randal Telfer

--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -416,32 +416,34 @@ INSTRUMENT_IFU_BROADENING_PARAMETERS = {
 
 # Alignment information about instrument internal pupil masks
 INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS = {
-    'NIRCam_SWA_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_SWA_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_SWA_MASK210R': {'pupil_shift_x': -0.0045, 'pupil_shift_y': -0.0019, 'pupil_rotation': -0.338},  # From M. Perrin, fits to ref star from pid 1411,
-    'NIRCam_SWA_MASK335R': {'pupil_shift_x': 0.0090, 'pupil_shift_y': 0.0013, 'pupil_rotation': -0.083}, # from K. Lawson, fits to ref star from pid 4050
-    'NIRCam_SWA_MASK430R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_LWA_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_LWA_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_LWA_MASK210R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'NIRCam_LWA_MASK335R': {'pupil_shift_x': -0.0134, 'pupil_shift_y': -0.0076, 'pupil_rotation': -0.56},  # from K. Lawson, fits to ERS progid 1386 data
-    'NIRCam_LWA_MASK430R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    # Draft placeholder values for MIRI based on Wright, Sabatke, & Telfer 2023.
+    'NIRCAM_SWA_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCAM_SWA_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCAM_SWA_MASK210R': {'pupil_shift_x': -0.0045, 'pupil_shift_y': -0.0019, 'pupil_rotation': -0.338},  # From M. Perrin, fits to ref star from pid 1411,
+    'NIRCAM_SWA_MASK335R': {'pupil_shift_x': 0.0090, 'pupil_shift_y': 0.0013, 'pupil_rotation': -0.083}, # from K. Lawson, fits to ref star from pid 4050
+    'NIRCAM_SWA_MASK430R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCAM_LWA_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCAM_LWA_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCAM_LWA_MASK210R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    'NIRCAM_LWA_MASK335R': {'pupil_shift_x': -0.0134, 'pupil_shift_y': -0.0076, 'pupil_rotation': -0.56},  # from K. Lawson, fits to ERS progid 1386 data
+    'NIRCAM_LWA_MASK430R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    # Draft placeholder values for MIRI based on Wright, Sabatke, & Telfer, 2022, Proc. SPIE
     #    (∆V2, ∆V3) = (0.68%, -1.1%)
-    # note, sign flip in Y compared to that paper, since this is applied at MIRI's
+    # note, sign is intentionally flipped in Y compared to that paper, since this is applied at MIRI's
     # internal exit pupil image, which is flipped in Y relative to the primary entrance pupil
     # These are *placeholder* values, and are pending refinement
-    'MIRI_MASKFQPM_F1065C': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
-    'MIRI_MASKFQPM_F11140': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
-    'MIRI_MASKFQPM_F1550C': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
-    'MIRI_MASKLYOT': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
+    'MIRI_MASKFQPM_FQPM1065': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
+    'MIRI_MASKFQPM_FQPM1140': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
+    'MIRI_MASKFQPM_FQPM1550': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
+    'MIRI_MASKLYOT_LYOT2300': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
 }
 
 # The coronagraph mask central wavelengths as-built may not precisely match the nominal design wavelengths.
 # In particular there's a measured offset for the F1140C mask
 MIRI_CORONAGRAPH_CENTRAL_WAVELENGTHS = {
         'FQPM1065': 10.65e-6,
-        'FQPM1140': 11.40e-6*1.03,   # priv. comm. A. Boccaletti and P. Baudoz
+        'FQPM1140': 11.30e-6*1.03,   # priv. comm. A. Boccaletti and P. Baudoz. Empirically the best fit is 1.03 times the
+                                     #   filter central wavelength which is 11.3 microns,  distinct from the mask's
+                                     #   nominal wavelength of 11.40 microns.
         'FQPM1550': 15.50e-6,
         }
 

--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -414,7 +414,7 @@ INSTRUMENT_IFU_BROADENING_PARAMETERS = {
     'MIRI': {'sigma': 0.05},
 }
 
-# Alignment information about instrument internal pupil masks (
+# Alignment information about instrument internal pupil masks
 INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS = {
     'NIRCam_SWA_MASKSWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
     'NIRCam_SWA_MASKLWB': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
@@ -426,10 +426,15 @@ INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS = {
     'NIRCam_LWA_MASK210R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
     'NIRCam_LWA_MASK335R': {'pupil_shift_x': -0.012, 'pupil_shift_y': -0.023, 'pupil_rotation': -0.60},  # from K. Lawson, fits to ERS progid 1386 data
     'NIRCam_LWA_MASK430R': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'MIRI_MASKFQPM_F1065C': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'MIRI_MASKFQPM_F11140': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'MIRI_MASKFQPM_F1550C': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
-    'MIRI_MASKLYOT': {'pupil_shift_x': None, 'pupil_shift_y': None, 'pupil_rotation': None},
+    # Draft placeholder values for MIRI based on Wright, Sabatke, & Telfer 2023.
+    #    (∆V2, ∆V3) = (0.68%, -1.1%)
+    # note, sign flip in Y compared to that paper, since this is applied at MIRI's
+    # internal exit pupil image, which is flipped in Y relative to the primary entrance pupil
+    # These are *placeholder* values, and are pending refinement
+    'MIRI_MASKFQPM_F1065C': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
+    'MIRI_MASKFQPM_F11140': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
+    'MIRI_MASKFQPM_F1550C': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
+    'MIRI_MASKLYOT': {'pupil_shift_x': 0.0068, 'pupil_shift_y': 0.011, 'pupil_rotation': None},
 }
 
 # Information about the effects on WFE of the IEC thermal variations

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -1385,7 +1385,12 @@ class JWInstrument(SpaceTelescopeInstrument):
             return 0, 0, None
 
         if not lookup_key:
-            lookup_key = self.name + '_' + self.pupil_mask
+            if self.name == 'NIRCam':
+                # This is complicated. Depends on the channel, and the image plane mask used...
+                # TODO more work needed here.
+                lookup_key = f'{self.name}_{self.channel[0].upper()}W{self.module}_' + self.pupil_mask
+            else:
+                lookup_key = self.name + '_' + self.pupil_mask
 
         values = []
         for param in ('pupil_shift_x', 'pupil_shift_y', 'pupil_rotation'):

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -1380,6 +1380,10 @@ class JWInstrument(SpaceTelescopeInstrument):
             Pupil shifts, expressed in meters. And rotation in degrees.
 
         """
+        if not self.pupil_mask:
+            # if there is no pupil stop mask, these have no effect, so no need to do anything more to find values
+            return 0, 0, None
+
         if not lookup_key:
             lookup_key = self.name + '_' + self.pupil_mask
 

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -1358,41 +1358,49 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         return newopd
 
-    def _get_pupil_shift(self):
-        """Return a tuple of pupil shifts, for passing to OpticalElement constructors
-        This is a minor utility function that gets used in most of the subclass optical
+    def _get_pupil_mask_alignment(self, lookup_key=None):
+        """Return a tuple of pupil shifts and rotation, for passing to OpticalElement constructors
+        This is a utility function that gets used in most of the subclass optical
         system construction.
 
+        This has two main parts:
+        1. Determine values for the pupil mask shift X, Y, and rotation, which can either be from:
+            1a) Explicitly provided by the user in self.options
+            1b) Or else, (optional) default positions per each mask, set in constants.py
+            1c) Otherwise return None
+        2. Convert any pupil mask shift X, Y from fractions of the pupil to offsets in meters
+        projected into the primary aperture.
         For historical reasons, the pupil_shift_x and pupil_shift_y options are expressed
         in fractions of the pupil. The parameters to poppy should now be expressed in
         meters of shift. So the translation of that happens here.
 
         Returns
         -------
-        shift_x, shift_y : floats or Nones
-            Pupil shifts, expressed in meters.
+        shift_x, shift_y, rotation : floats or Nones
+            Pupil shifts, expressed in meters. And rotation in degrees.
 
         """
-        if ('pupil_shift_x' in self.options and self.options['pupil_shift_x'] != 0) or (
-            'pupil_shift_y' in self.options and self.options['pupil_shift_y'] != 0
-        ):
-            from .constants import JWST_CIRCUMSCRIBED_DIAMETER
+        if not lookup_key:
+            lookup_key = self.name + '_' + self.pupil_mask
 
-            # missing values are treated as 0's
-            shift_x = self.options.get('pupil_shift_x', 0)
-            shift_y = self.options.get('pupil_shift_y', 0)
-            # nones are likewise treated as 0's
-            if shift_x is None:
-                shift_x = 0
-            if shift_y is None:
-                shift_y = 0
-            # Apply pupil scale
-            shift_x *= JWST_CIRCUMSCRIBED_DIAMETER
-            shift_y *= JWST_CIRCUMSCRIBED_DIAMETER
-            _log.info('Setting Lyot pupil shift to ({}, {})'.format(shift_x, shift_y))
-        else:
-            shift_x, shift_y = None, None
-        return shift_x, shift_y
+        values = []
+        for param in ('pupil_shift_x', 'pupil_shift_y', 'pupil_rotation'):
+            val = self.options.get(param)  # has user directly provided a value?
+            # if not, check if we have a default for this instrument + mask
+            if (val is None) and (lookup_key in constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS):
+                val = constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS[lookup_key].get(param)
+                _log.debug(f' Found default {lookup_key} {param} = {val}')
+
+            if val is not None and param.startswith('pupil_shift'):
+                val *= constants.JWST_CIRCUMSCRIBED_DIAMETER
+            values.append(val)
+
+        shift_x, shift_y, rotation = values
+
+        if any(values):
+            _log.info(f"Setting instrument pupil mask shift to ({shift_x}, {shift_y}), rotation={rotation}")
+
+        return shift_x, shift_y, rotation
 
     def _apply_jitter(self, result, local_options=None):
         """Modify a PSF to account for the blurring effects of image jitter.
@@ -2312,8 +2320,7 @@ class MIRI(JWInstrument_with_IFU):
             optsys.add_pupil(poppy.FQPM_FFT_aligner(direction='backward'))
 
         # add pupil plane mask
-        shift_x, shift_y = self._get_pupil_shift()
-        rotation = self.options.get('pupil_rotation', None)
+        shift_x, shift_y, rotation = self._get_pupil_mask_alignment()
 
         if self.options.get('coron_include_pre_lyot_plane', False) and self.pupil_mask.startswith('MASK'):
             optsys.add_pupil(poppy.ScalarTransmission(name='Pre Lyot Stop'))
@@ -3024,8 +3031,7 @@ class NIRCam(JWInstrument):
             trySAM = False
 
         # add pupil plane mask
-        shift_x, shift_y = self._get_pupil_shift()
-        rotation = self.options.get('pupil_rotation', None)
+        shift_x, shift_y, rotation = self._get_pupil_mask_alignment()
 
         if self.pupil_mask == 'CIRCLYOT' or self.pupil_mask == 'MASKRND':
             optsys.add_pupil(
@@ -3552,8 +3558,7 @@ class NIRISS(JWInstrument):
             radius = 0.0  # irrelevant but variable needs to be initialized
 
         # add pupil plane mask
-        shift_x, shift_y = self._get_pupil_shift()
-        rotation = self.options.get('pupil_rotation', None)
+        shift_x, shift_y, rotation = self._get_pupil_mask_alignment()
 
         # Note - the syntax for specifying shifts is different between FITS files and
         # AnalyticOpticalElement instances. Annoying but historical.

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -1388,17 +1388,27 @@ class JWInstrument(SpaceTelescopeInstrument):
             if self.name == 'NIRCam':
                 # This is complicated. Depends on the channel, and the image plane mask used...
                 # TODO more work needed here.
-                lookup_key = f'{self.name}_{self.channel[0].upper()}W{self.module}_' + self.pupil_mask
+                lookup_key = f'{self.name.upper()}_{self.channel[0].upper()}W{self.module}_{self.image_mask}'
+            elif self.name == 'MIRI':
+                lookup_key = f'{self.name}_{self.pupil_mask}_{self.image_mask}'
             else:
-                lookup_key = self.name + '_' + self.pupil_mask
+                lookup_key = f'{self.name}_{self.pupil_mask}'
+            _log.debug("Looking up default pupil mask alignment params for "+lookup_key)
 
         values = []
-        for param in ('pupil_shift_x', 'pupil_shift_y', 'pupil_rotation'):
+        header_keywords = ('PUPLSHFX', 'PUPLSHFY', 'PUPL_ROT')
+                           #[%] Coronagraph Lyot pupil X shift rel. to prim
+        header_comments = ('Coron. Lyot pupil X shift relative to primary',
+                           'Coron. Lyot pupil Y shift relative to primary',
+                           '[deg] Coron. Lyot pupil rotation rel. to prim.',)
+        for i, param in enumerate(('pupil_shift_x', 'pupil_shift_y', 'pupil_rotation')):
             val = self.options.get(param)  # has user directly provided a value?
             # if not, check if we have a default for this instrument + mask
             if (val is None) and (lookup_key in constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS):
                 val = constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS[lookup_key].get(param)
                 _log.debug(f' Found default {lookup_key} {param} = {val}')
+
+            self._extra_keywords[header_keywords[i]] = (val if val is not None else 0, header_comments[i])
 
             if val is not None and param.startswith('pupil_shift'):
                 val *= constants.JWST_CIRCUMSCRIBED_DIAMETER
@@ -2124,8 +2134,10 @@ class MIRI(JWInstrument_with_IFU):
         # Coordinate system note:
         # The pupil shifts get applied at the instrument pupil, which is an image of the OTE exit pupil
         # and is thus flipped in Y relative to the V frame entrance pupil. Therefore flip sign of pupil_shift_y
-        self.options['pupil_shift_x'] = -0.0068  # In flight measurement. See Wright, Sabatke, Telfer 2022, Proc SPIE
-        self.options['pupil_shift_y'] = -0.0110  # Sign intentionally flipped relative to that paper!! See note above.
+        # The default here is left as None, unspecified, which allows later selection of distinct default
+        # values based on mode. See method _get_pupil_mask_alignment()
+        self.options['pupil_shift_x'] = None
+        self.options['pupil_shift_y'] = None
 
         self.image_mask_list = ['FQPM1065', 'FQPM1140', 'FQPM1550', 'LYOT2300', 'LRS slit']
         self.pupil_mask_list = ['MASKFQPM', 'MASKLYOT', 'P750L']
@@ -2265,16 +2277,11 @@ class MIRI(JWInstrument_with_IFU):
                     poppy.SquareFieldStop(size=24, rotation=self._rotation, **offsets),
                 ],
             )
+            self._extra_keywords['FQPMWAVE'] = (wavelength, '[m] FQPM mask retardance reference wavelength')   # record the mask reference wavelength used in this calculation
             return container
 
-        if self.image_mask == 'FQPM1065':
-            optsys.add_image(make_fqpm_wrapper('MIRI FQPM 1065', constants.MIRI_CORONAGRAPH_CENTRAL_WAVELENGTHS['FQPM1065']))
-            trySAM = False
-        elif self.image_mask == 'FQPM1140':
-            optsys.add_image(make_fqpm_wrapper('MIRI FQPM 1140', constants.MIRI_CORONAGRAPH_CENTRAL_WAVELENGTHS['FQPM1065']))
-            trySAM = False
-        elif self.image_mask == 'FQPM1550':
-            optsys.add_image(make_fqpm_wrapper('MIRI FQPM 1550', constants.MIRI_CORONAGRAPH_CENTRAL_WAVELENGTHS['FQPM1065']))
+        if self.image_mask in ['FQPM1065', 'FQPM1140', 'FQPM1550']:
+            optsys.add_image(make_fqpm_wrapper('MIRI '+self.image_mask, constants.MIRI_CORONAGRAPH_CENTRAL_WAVELENGTHS[self.image_mask]))
             trySAM = False
         elif self.image_mask == 'LYOT2300':
             # diameter is 4.25 (measured) 4.32 (spec) supposedly 6 lambda/D
@@ -2612,8 +2619,9 @@ class NIRCam(JWInstrument):
         self._pixelscale_long = self._get_pixelscale_from_apername('NRCA5_FULL')
         self.pixelscale = self._pixelscale_short
 
-        self.options['pupil_shift_x'] = 0  # Set to 0 since NIRCam FAM corrects for PM shear in flight
-        self.options['pupil_shift_y'] = 0
+        self.options['pupil_shift_x'] = None  # Set to None since NIRCam FAM corrects for PM shear in flight
+        self.options['pupil_shift_y'] = None  # Making this None rather than 0 allows for later implementation of
+                                              # distinct default values for coronagraphy.
 
         # Enable the auto behaviours by default (after superclass __init__)
         self.auto_channel = True

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -2268,13 +2268,13 @@ class MIRI(JWInstrument_with_IFU):
             return container
 
         if self.image_mask == 'FQPM1065':
-            optsys.add_image(make_fqpm_wrapper('MIRI FQPM 1065', 10.65e-6))
+            optsys.add_image(make_fqpm_wrapper('MIRI FQPM 1065', constants.MIRI_CORONAGRAPH_CENTRAL_WAVELENGTHS['FQPM1065']))
             trySAM = False
         elif self.image_mask == 'FQPM1140':
-            optsys.add_image(make_fqpm_wrapper('MIRI FQPM 1140', 11.40e-6))
+            optsys.add_image(make_fqpm_wrapper('MIRI FQPM 1140', constants.MIRI_CORONAGRAPH_CENTRAL_WAVELENGTHS['FQPM1065']))
             trySAM = False
         elif self.image_mask == 'FQPM1550':
-            optsys.add_image(make_fqpm_wrapper('MIRI FQPM 1550', 15.50e-6))
+            optsys.add_image(make_fqpm_wrapper('MIRI FQPM 1550', constants.MIRI_CORONAGRAPH_CENTRAL_WAVELENGTHS['FQPM1065']))
             trySAM = False
         elif self.image_mask == 'LYOT2300':
             # diameter is 4.25 (measured) 4.32 (spec) supposedly 6 lambda/D

--- a/stpsf/tests/test_miri.py
+++ b/stpsf/tests/test_miri.py
@@ -67,6 +67,10 @@ def do_test_miri_fqpm(
         psf.writeto(fn, clobber=clobber)
 
     # FIXME - add some assertion tests here.
+    # Check that we have set the pupil shifts based on the default
+    assert psf[0].header['PUPLSHFX'] == stpsf.constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS['MIRI_MASKFQPM_'+miri.image_mask]['pupil_shift_x']
+    assert psf[0].header['PUPLSHFY'] == stpsf.constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS['MIRI_MASKFQPM_'+miri.image_mask]['pupil_shift_y']
+    assert psf[0].header['FQPMWAVE'] == stpsf.constants.MIRI_CORONAGRAPH_CENTRAL_WAVELENGTHS[miri.image_mask]
 
 
 def test_miri_fqpm_centered(*args, **kwargs):

--- a/stpsf/tests/test_nircam.py
+++ b/stpsf/tests/test_nircam.py
@@ -211,6 +211,11 @@ def do_test_nircam_blc(clobber=False, kind='circular', angle=0, save=False, disp
         _log.info('File {0} has the expected total flux based on prior reference calculation: {1}'.format(fnout, totflux))
 
     # _log.info("Lots of test files output as test_nircam_*.fits")
+    # Check that we have set the pupil shifts based on the default
+    chan= 'SW' if nc.channel == 'short' else 'LW'
+    assert psf[0].header['PUPLSHFX'] == stpsf.constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS[f'NIRCAM_{chan}{nc.module}_{nc.image_mask}']['pupil_shift_x']
+    assert psf[0].header['PUPLSHFY'] == stpsf.constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS[f'NIRCAM_{chan}{nc.module}_{nc.image_mask}']['pupil_shift_y']
+
 
 
 def test_nircam_get_detector():

--- a/stpsf/tests/test_nircam.py
+++ b/stpsf/tests/test_nircam.py
@@ -213,8 +213,14 @@ def do_test_nircam_blc(clobber=False, kind='circular', angle=0, save=False, disp
     # _log.info("Lots of test files output as test_nircam_*.fits")
     # Check that we have set the pupil shifts based on the default
     chan= 'SW' if nc.channel == 'short' else 'LW'
-    assert psf[0].header['PUPLSHFX'] == stpsf.constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS[f'NIRCAM_{chan}{nc.module}_{nc.image_mask}']['pupil_shift_x']
-    assert psf[0].header['PUPLSHFY'] == stpsf.constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS[f'NIRCAM_{chan}{nc.module}_{nc.image_mask}']['pupil_shift_y']
+
+    def get_default_val(paramname):
+        # Lookup value from the constants file. If it's None, return a 0 (so the returned value is always a number)
+        val = stpsf.constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS[f'NIRCAM_{chan}{nc.module}_{nc.image_mask}'][val]
+        return val if val is not None else 0
+
+    assert psf[0].header['PUPLSHFX'] == get_default_val('pupil_shift_x')
+    assert psf[0].header['PUPLSHFY'] == get_default_val('pupil_shift_y')
 
 
 

--- a/stpsf/tests/test_nircam.py
+++ b/stpsf/tests/test_nircam.py
@@ -216,7 +216,7 @@ def do_test_nircam_blc(clobber=False, kind='circular', angle=0, save=False, disp
 
     def get_default_val(paramname):
         # Lookup value from the constants file. If it's None, return a 0 (so the returned value is always a number)
-        val = stpsf.constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS[f'NIRCAM_{chan}{nc.module}_{nc.image_mask}'][val]
+        val = stpsf.constants.INSTRUMENT_PUPIL_MASK_DEFAULT_POSITIONS[f'NIRCAM_{chan}{nc.module}_{nc.image_mask}'][paramname]
         return val if val is not None else 0
 
     assert psf[0].header['PUPLSHFX'] == get_default_val('pupil_shift_x')


### PR DESCRIPTION
**[relocated from https://github.com/spacetelescope/webbpsf/pull/675]**

This PR implements a capability to have default mask alignment options (`pupil_shift_x, pupil_shift_y, pupil_rotation`) defined per each coronagraph mask. This is intended to allow WebbPSF to include measured in-flight information on the various masks. 

Implementation details: 
- in `constants.py` add a dict which gives values of these options per each mask, or else None to leave undefined
- in `webbpsf_core.py`, update code to look up and use those values. 

_WORK IN PROGRESS, NOT YET COMPLETE, NOT READY TO MERGE_ 