### PR TITLE
Improved model for MIRI cruciform artifact, part 2

### DIFF
--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -300,7 +300,6 @@ Please note, the minimum supported version of Python is increaed to Python 3.10,
 
 **Full Changelog**: https://github.com/spacetelescope/stpsf/compare/v1.2.1...v1.3.0.rc1
 
-
 Version 1.2.1
 =============
 Minor documentation updates

--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -414,6 +414,15 @@ INSTRUMENT_IFU_BROADENING_PARAMETERS = {
     'MIRI': {'sigma': 0.05},
 }
 
+# Various parameters to model the more complex parts of the MIRI cruciform artifact
+# There's a fair amount of ad-hoc tuning still needed here to match real data
+MIRI_CRUCIFORM_PEAK_REFWAVE = 5.5  #  # See Gaspar et al. sections 4.2 and 4.3
+MIRI_CRUCIFORM_PEAKS_LOC = [12/1.1, 16.5,   19.5, 23.5, 27.9, 33, 39.6]  # pixels, at 5.5 microns, for the centered PSF; slightly tuned to in-flight ePSFs
+MIRI_CRUCIFORM_PEAKS_AMP = [1.8e-4, 1.0e-4, 1.0e-4, 9e-5, 4e-5, 2e-5, 1e-5]  # read off from fig 12 in Gaspar et al.  Slightly tuned to in-flight ePSFs.
+MIRI_CRUCIFORM_PEAKS_AMP_ADJUST = 20        # ad hoc scale factor, for units conversion from fig 12 to how it's normalized here 
+MIRI_CRUCIFORM_PEAKS_SIGMA = 1              # how wide are the peaks/bumps along the crucifor
+
+
 # Information about the effects on WFE of the IEC thermal variations
 #
 # Table of value for IEC telemetry to WFE model. Coefficients from model fit by Randal Telfer
@@ -432,3 +441,4 @@ iec_mnemonics = (
     # uncertainties in amplitude are ± 0.039 - 0.106 nm/K
     # uncertainties in lag are ± 0.075 - 0.109 min
 )
+

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -344,11 +344,33 @@ def _make_miri_scattering_kernel_2d(in_psf, kernel_amp, oversample=1, wavelength
     kernel_x[np.abs(x) < constants.MIRI_CRUCIFORM_INNER_RADIUS_PIX] *= 0.5
     kernel_y[np.abs(y) < constants.MIRI_CRUCIFORM_INNER_RADIUS_PIX] *= 0.5
 
-    # Add in the offset copies of the main 1d kernels
+    # add in the extra diffraction peaks into each 1d kernel, as seen in Gaspar et al. 2021
+    # but first, save the total flux for normalization later
+    normfactor = kernel_x.sum()
+
     # Empirically, the 'center' of the cruciform shifts inwards towards the center of the detector
-    # i.e. for the upper right corner, the cruciform shifts down and left a bit, etc.
+    # i.e. for the upper right corner, the cruciform shifts down and left a bit, etc. 
+    # Turns out the centers of the peaks in each cruciform arm also seem to shift a bit, so
+    # let's use the same shifts to try to model those, with some scale factor
     yshift = cruciform_yshifts(detector_position[1])
     xshift = cruciform_xshifts(detector_position[0])
+
+    for loc, amp in zip(constants.MIRI_CRUCIFORM_PEAKS_LOC, constants.MIRI_CRUCIFORM_PEAKS_AMP):
+        # Empirically, the locations of the peaks shift slightly around the FOV, in the opposite sign as the cruciform itself shifts
+        # we model this ad hoc based on comparisons iwth the ePSF data.
+        # The scale factors here are a bit of a handwave by eye, not yet a rigorous fit...
+        scaled_loc_x = loc * wavelength / constants.MIRI_CRUCIFORM_PEAK_REFWAVE * 1.1
+        scaled_loc_y = loc * wavelength / constants.MIRI_CRUCIFORM_PEAK_REFWAVE * 1.1
+
+        scaled_amp = amp * constants.MIRI_CRUCIFORM_PEAKS_AMP_ADJUST  # ad hoc, to make it work; basically a units scale factor from the plot in Andras' paper 
+        peak_x = scaled_amp * np.exp(-(x-scaled_loc_x + xshift/2)**2) + scaled_amp * np.exp(-(x+scaled_loc_x + xshift/2)**2)
+        peak_y = scaled_amp * np.exp(-(y-scaled_loc_y + yshift/2)**2) + scaled_amp * np.exp(-(y+scaled_loc_y + yshift/2)**2)
+        kernel_x += peak_x
+        kernel_y += peak_y
+    kernel_x *= normfactor/kernel_x.sum()
+    kernel_y *= normfactor/kernel_y.sum()
+
+    # Add in the offset copies of the main 1d kernels
     kernel_2d[cen + int(round(yshift * oversample))] = kernel_x
     kernel_2d[:, cen + int(round(xshift * oversample))] = kernel_y
 


### PR DESCRIPTION
**[Relocated from https://github.com/spacetelescope/webbpsf/pull/838]**

This is the second portion of an improved model for the MIRI cruciform artifacts, began in #837 . This PR should stay draft and not be merged until after #837 is merged; this branch is branched off of the PR #837 branch. Besides it's still more of a work in progress. 

This PR adds an attempt at modeling the peaks or bumps within the cruciform, as predicted in  [Gaspar et al. 2021](https://iopscience.iop.org/article/10.1088/1538-3873/abcd04/pdf). See their Figure 12 in particular. 

I have attempted to take the values stated in section 4.3 of that paper, for the m=4 to 10 order peaks, and apply some scale factors to get models of those in webbpsf, and tune a bit to match the empirical PSFs. This is complex and messy however because the physics is very complex, there are many free parameters in this ad hoc parameterizatation, and the available MIRI ePSFs are of modest SNR. Not sure how tractable this is; for now it's a work in progress. 

Motivated in part by seeking to understand the complex diffractive structure seen in dispersed LRS PSFs at short wavelengths. 


### Examples

- Data: [miri_epsfs_F560W_measured.pdf](https://github.com/spacetelescope/webbpsf/files/15203423/miri_epsfs_F560W_measured.pdf)
- With PR #837: [miri_epsfs_F560W_sim_new.pdf](https://github.com/spacetelescope/webbpsf/files/15203438/miri_epsfs_F560W_sim_new.pdf)
 - with this PR: [miri_epsfs_F560W_sim_new_v2.pdf](https://github.com/spacetelescope/webbpsf/files/15203822/miri_epsfs_F560W_sim_new_v2.pdf)
