### PR TITLE
Implement MIRI IFU empirical cruciform

### DIFF
--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -411,7 +411,9 @@ MIRI_CRUCIFORM_RADIAL_SCALEFACTOR = 0.005   # Brightness factor for the diffuse 
 # Parameters for adjusting models of IFU PSFs relative to regular imaging PSFs
 INSTRUMENT_IFU_BROADENING_PARAMETERS = {
     'NIRSPEC': {'sigma': 0.05},
-    'MIRI': {'sigma': 0.05, 'fhwm_cruciform': 15, "offset_cruciform": -3},
+    'MIRI': {'sigma': 0.05,
+             'fwhm_cruciform': 15,
+             "offset_cruciform": -3},
 }
 
 # Information about the effects on WFE of the IEC thermal variations

--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -411,7 +411,7 @@ MIRI_CRUCIFORM_RADIAL_SCALEFACTOR = 0.005   # Brightness factor for the diffuse 
 # Parameters for adjusting models of IFU PSFs relative to regular imaging PSFs
 INSTRUMENT_IFU_BROADENING_PARAMETERS = {
     'NIRSPEC': {'sigma': 0.05},
-    'MIRI': {'sigma': 0.05},
+    'MIRI': {'sigma': 0.05, 'fhwm_cruciform': 15, "offset_cruciform": -3},
 }
 
 # Information about the effects on WFE of the IEC thermal variations

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -612,9 +612,9 @@ def apply_miri_ifu_broadening(hdulist, options, slice_width=0.196):
         out = _miri_mrs_empirical_broadening(psf_model=hdulist[ext].data, alpha_width=alpha_width, beta_width=beta_width)
         if wavelen * 1e6 <= 7.5:
             amplitude_cruciform = get_mrs_cruciform_amplitude(wavelen * 1e6)
-            oversample_factor = hdulist[ext].header['DET_SAMP']/7  # optimised parameters with oversampling = 7
-            fwhm_cruciform = constants.INSTRUMENT_IFU_BROADENING_PARAMETERS["MIRI"]["fwhm_cruciform"]*oversample_factor
-            offset_cruciform = constants.INSTRUMENT_IFU_BROADENING_PARAMETERS["MIRI"]["offset_cruciform"]*oversample_factor
+            oversample_factor = hdulist[ext].header['DET_SAMP'] / 7  # optimised parameters with oversampling = 7
+            fwhm_cruciform = constants.INSTRUMENT_IFU_BROADENING_PARAMETERS["MIRI"]["fwhm_cruciform"] * oversample_factor
+            offset_cruciform = constants.INSTRUMENT_IFU_BROADENING_PARAMETERS["MIRI"]["offset_cruciform"] * oversample_factor
             out = _miri_mrs_empirical_cruciform(psf_model=out, amp=amplitude_cruciform,
                                                 fwhm=fwhm_cruciform, x_0=offset_cruciform)
 
@@ -701,7 +701,7 @@ def get_mrs_cruciform_amplitude(wavelen):
     Empirical amplitude of additional cruciform component in MIRI IFU data
     wavelen: wavelength (only applicable if wavelength < 7.5 um - see apply_miri_ifu_broadening)
     """
-    return -0.16765378*wavelen + 1.23632423  # Patapis 2025 PSF paper
+    return -0.16765378 * wavelen + 1.23632423  # Patapis 2025 PSF paper
 
 
 def _round_up_to_odd_integer(value):
@@ -744,4 +744,4 @@ def _miri_mrs_empirical_cruciform(psf_model, amp, fwhm, x_0):
 
     # TODO: extend algorithm to handle the datacube case
     psf_model_cruciform = np.apply_along_axis(lambda m: convolve(m, kernel_cruciform), axis=1, arr=psf_model)
-    return psf_model+amp*psf_model_cruciform
+    return psf_model + amp * psf_model_cruciform

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -760,11 +760,16 @@ def _miri_mrs_empirical_cruciform(psf_model, amp, fwhm, x_0):
        amplitude of Lorentzian in pixels
     fwhm : float
        Full Width Half Max of Lorentzian in pixels
-   x_0 : float
+    x_0 : float
        offset of Lorentzian in pixels
     """
     kernel_cruciform = _Lorentz1DKernel(1.0, fwhm, x_0)
+    webbpsf.webbpsf_core._log.info(f'  MRS empirical cruciform: amp {amp} fwhm {fwhm} x_0 {x_0}')
+
+    # Flux conservation: the integral of the Lorentz kernel is the same as the amplitude
+    # therefore the following will keep the total flux conserved in the summed output PSF.
+    flux_conv_factor = 1 / (1 + amp)
 
     # TODO: extend algorithm to handle the datacube case
     psf_model_cruciform = np.apply_along_axis(lambda m: convolve(m, kernel_cruciform), axis=1, arr=psf_model)
-    return psf_model + amp * psf_model_cruciform
+    return flux_conv_factor * (psf_model + amp * psf_model_cruciform)

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -587,9 +587,9 @@ def apply_miri_ifu_broadening(hdulist, options, slice_width=0.196):
     model_type = options.get('ifu_broadening', 'empirical_cruciform')
 
     if model_type is None or model_type.lower() == 'none':
-        webbpsf.webbpsf_core._log.debug('MIRI MRS: IFU broadening option is set to None, skipping IFU PSF broadening effects.')
+        stpsf.stpsf_core._log.debug('MIRI MRS: IFU broadening option is set to None, skipping IFU PSF broadening effects.')
         return hdulist
-    webbpsf.webbpsf_core._log.debug('MIRI MRS: Adding IFU PSF broadening effects.')
+    stpsf.stpsf_core._log.debug('MIRI MRS: Adding IFU PSF broadening effects.')
 
     ext = 1  # Apply this effect to the OVERDIST extension, which at this point in the code will be ext 1
 
@@ -703,7 +703,7 @@ def _miri_mrs_empirical_broadening(psf_model, alpha_width, beta_width):
         slice width in pixels
     """
     kernel_beta = astropy.convolution.Box1DKernel(beta_width)
-    webbpsf.webbpsf_core._log.info(f'  MRS empirical broadening: alpha width {alpha_width}, beta width {beta_width}')
+    stpsf.stpsf_core._log.info(f'  MRS empirical broadening: alpha width {alpha_width}, beta width {beta_width}')
 
     # TODO: extend algorithm to handle the datacube case
 
@@ -760,7 +760,7 @@ def _miri_mrs_empirical_cruciform(psf_model, amp, fwhm, x_0):
     Parameters
     -----------
     psf_model : ndarray
-       webbpsf output results, either monochromatic model or datacube
+       stpsf output results, either monochromatic model or datacube
     amp : float
        amplitude of Lorentzian in pixels
     fwhm : float
@@ -769,7 +769,7 @@ def _miri_mrs_empirical_cruciform(psf_model, amp, fwhm, x_0):
        offset of Lorentzian in pixels
     """
     kernel_cruciform = _Lorentz1DKernel(1.0, fwhm, x_0)
-    webbpsf.webbpsf_core._log.info(f'  MRS empirical cruciform: amp {amp} fwhm {fwhm} x_0 {x_0}')
+    stpsf.stpsf_core._log.info(f'  MRS empirical cruciform: amp {amp} fwhm {fwhm} x_0 {x_0}')
 
     # Flux conservation: the integral of the Lorentz kernel is the same as the amplitude
     # therefore the following will keep the total flux conserved in the summed output PSF.

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -303,7 +303,7 @@ cruciform_xshifts = scipy.interpolate.interp1d([0, 357, 1031], [1.5, 0.5, -0.9],
 cruciform_yshifts = scipy.interpolate.interp1d([0, 511, 1031], [1.6, 0, -1.6], kind='linear', fill_value='extrapolate')
 
 
-def _make_miri_scattering_kernel_2d(in_psf, kernel_amp, oversample=1, wavelength=5.5, detector_position=(0, 0)):
+def _make_miri_cruciform_kernel_2d(in_psf, kernel_amp, oversample=1, wavelength=5.5, detector_position=(0, 0)):
     """Improved / more complex model of the MIRI cruciform, with parameterization to model
     additional features as seen in the GimMIRI models of Gaspar et al. 2021, PASP 133
     See in particular their Figure 12.
@@ -368,9 +368,9 @@ def _make_miri_scattering_kernel_2d(in_psf, kernel_amp, oversample=1, wavelength
     return kernel_2d
 
 
-def _apply_miri_scattering_kernel_2d(in_psf, kernel_2d, oversample):
+def _apply_miri_cruciform_kernel_2d(in_psf, kernel_2d, oversample):
     """
-    Applies the detector scattering kernel created in _make_miri_scattering_kernel
+    Applies the detector scattering kernel created in _make_miri_cruciform_kernel_2d
     function to an input image. Code is adapted from
     MIRI-TN-00076-ATC_Imager_PSF_Issue_4.pdf
 
@@ -378,9 +378,8 @@ def _apply_miri_scattering_kernel_2d(in_psf, kernel_2d, oversample):
     ----------
     in_psf : ndarray
         PSF array upon which to apply the kernel
-    kernel_x : ndarray
-        The 1D kernel in the x direction, output from _make_miri_scattering_kernel.
-        This will be transposed to create the kernel in the y direction.
+    kernel_2d : ndarray
+        The 2D kernel, output from _make_miri_cruciform_kernel_2d.
     oversample : int
         Amount by which the input PSF is oversampled
 
@@ -449,7 +448,7 @@ def get_miri_cruciform_amplitude(filt):
     return kernel_amp
 
 
-def apply_miri_scattering(hdulist_or_filename=None, kernel_amp=None, old_method=False):
+def apply_miri_imager_cruciform(hdulist_or_filename=None, kernel_amp=None, old_method=False):
     """
     Apply a distortion caused by the MIRI scattering cross artifact effect.
     In short we convolve a 2D exponentially decaying cross to the PSF where
@@ -461,6 +460,9 @@ def apply_miri_scattering(hdulist_or_filename=None, kernel_amp=None, old_method=
     input PSF is calculated as Extension 0, the calling function must put a copy of that into Extension 1
     which this will then modify. This happens in stpsf_core.py/JWInstrument._calc_psf_format_output,
     which is where this is called from in the usual course of operation.
+
+    Note - this function is called only for **MIRI IMAGER** simulations.
+    For MRS, see instead the apply_miri_ifu_broadening function, below.
 
     Parameters
     ----------
@@ -508,14 +510,14 @@ def apply_miri_scattering(hdulist_or_filename=None, kernel_amp=None, old_method=
     in_psf = psf[ext].data
 
     # create cruciform model using improved method using a 2d convolution kernel, attempting to model more physics.
-    kernel_2d = _make_miri_scattering_kernel_2d(
+    kernel_2d = _make_miri_cruciform_kernel_2d(
         in_psf,
         kernel_amp,
         oversample,
         detector_position=(hdu_list[0].header['DET_X'], hdu_list[0].header['DET_Y']),
         wavelength=hdu_list[0].header['WAVELEN'] * 1e6,
     )
-    im_conv_both = _apply_miri_scattering_kernel_2d(in_psf, kernel_2d, oversample)
+    im_conv_both = _apply_miri_cruciform_kernel_2d(in_psf, kernel_2d, oversample)
 
     # Add this 2D scattered light output to the PSF
     psf_new = in_psf + im_conv_both
@@ -535,14 +537,16 @@ def apply_miri_scattering(hdulist_or_filename=None, kernel_amp=None, old_method=
 
 
 def _show_miri_cruciform_kernel(filt, npix=101, oversample=4, detector_position=(512, 512), ax=None):
-    """utility function for viewing/visualizing the cruciform kernel"""
+    """utility function for viewing/visualizing the cruciform kernel.
+    This displays a plot on screen, as a user convenience.
+    This display function is Not used as part of PSF calculations."""
     import matplotlib
 
     placeholder = np.zeros((npix * oversample, npix * oversample))
     kernel_amp = get_miri_cruciform_amplitude(filt)
     extent = [-npix / 2, npix / 2, -npix / 2, npix / 2]
 
-    kernel_2d = _make_miri_scattering_kernel_2d(placeholder, kernel_amp, oversample, detector_position=detector_position)
+    kernel_2d = _make_miri_cruciform_kernel_2d(placeholder, kernel_amp, oversample, detector_position=detector_position)
     norm = matplotlib.colors.LogNorm(1e-6, 1)
     cmap = matplotlib.cm.viridis
     cmap.set_bad(cmap(0))
@@ -563,6 +567,9 @@ def _show_miri_cruciform_kernel(filt, npix=101, oversample=4, detector_position=
 
 def apply_miri_ifu_broadening(hdulist, options, slice_width=0.196):
     """ Apply a simple empirical model of MIRI IFU broadening to better match observed PSFs
+
+    Note - this function is called only for **MIRI MRS** simulations.
+    For MRS, see instead the apply_miri_imager_cruciform function, above.
 
     Parameters
     -----------

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -587,7 +587,9 @@ def apply_miri_ifu_broadening(hdulist, options, slice_width=0.196):
     model_type = options.get('ifu_broadening', 'empirical_cruciform')
 
     if model_type is None or model_type.lower() == 'none':
+        webbpsf.webbpsf_core._log.debug('MIRI MRS: IFU broadening option is set to None, skipping IFU PSF broadening effects.')
         return hdulist
+    webbpsf.webbpsf_core._log.debug('MIRI MRS: Adding IFU PSF broadening effects.')
 
     ext = 1  # Apply this effect to the OVERDIST extension, which at this point in the code will be ext 1
 

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -627,6 +627,8 @@ def apply_miri_ifu_broadening(hdulist, options, slice_width=0.196):
             offset_cruciform = constants.INSTRUMENT_IFU_BROADENING_PARAMETERS["MIRI"]["offset_cruciform"] * oversample_factor
             out = _miri_mrs_empirical_cruciform(psf_model=out, amp=amplitude_cruciform,
                                                 fwhm=fwhm_cruciform, x_0=offset_cruciform)
+    # enforce strict flux conservation
+    out *= hdulist[ext].data.sum() / out.sum()
 
     hdulist[ext].data = out
 

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -295,7 +295,7 @@ def oversample_ipc_model(kernel, oversample):
     return kernel_oversample
 
 
-# Functions for applying MIRI Detector Scattering Effect
+# Functions for applying MIRI Cruciform Detector "Scattering" Diffraction Effect
 
 # Lookup tables of shifts of the cruciform
 # Estimated roughly from F560W ePSFs (ePSFs by Libralatto, shift estimate by Perrin)
@@ -558,6 +558,7 @@ def _show_miri_cruciform_kernel(filt, npix=101, oversample=4, detector_position=
 
     matplotlib.pyplot.colorbar(mappable=ax.images[0])
 
+
 # Functions for applying IFU optics systematics models
 #
 # Note, this is not actually a "Detector" effect, but this file is a
@@ -617,6 +618,7 @@ def apply_miri_ifu_broadening(hdulist, options, slice_width=0.196):
         beta_width = slice_width / pixelscl
         alpha_width = _miri_mrs_analytical_sigma_alpha_broadening(wavelen * 1e6) / pixelscl
         out = _miri_mrs_empirical_broadening(psf_model=hdulist[ext].data, alpha_width=alpha_width, beta_width=beta_width)
+
         if wavelen * 1e6 <= 7.5:
             amplitude_cruciform = get_mrs_cruciform_amplitude(wavelen * 1e6)
             oversample_factor = hdulist[ext].header['DET_SAMP'] / 7  # optimised parameters with oversampling = 7
@@ -659,10 +661,12 @@ def apply_nirspec_ifu_broadening(hdulist, options):
     return hdulist
 
 
+# Functions for modeling MIRI MRS effects, including both the cruciform (as seen in the MRS) and other IFU broadening.
+# Invoked from apply_miri_ifu_broadening, above.
+
 def _miri_mrs_analytical_sigma_alpha_broadening(wavelength):
-    """
-    Calculate the Gaussian scale of the kernel that broadens the diffraction limited
-    FWHM to the empirically measured FWHM.
+    """ Calculate the Gaussian scale of the kernel that broadens the MRS IFU PSF,
+    from the diffraction limited FWHM to the empirically measured FWHM.
 
     Parameters
     ----------
@@ -678,40 +682,51 @@ def _miri_mrs_analytical_sigma_alpha_broadening(wavelength):
 
 
 def _miri_mrs_empirical_broadening(psf_model, alpha_width, beta_width):
-     """
-     Perform the broadening of a psf model in alpha and beta
+    """ Perform the broadening of a MRS PSF model in alpha and beta.
+    This only includes the IFU broadening. See also _miri_mrs_empirical_cruciform
 
-     Parameters
-     -----------
-     psf_model : ndarray
+    The beta (across-slice) convolution is implemented as a Box1D kernel
+    The alpha (along-slice) convolution is implemented as a Gaussian kernel
+
+    Parameters
+    -----------
+    psf_model : ndarray
         stpsf output results, eitehr monochromatic model or datacube
-     alpha_width : float
+    alpha_width : float
         gaussian convolution kernel in pixels, None if no broadening should be performed
-     beta_width : float
+    beta_width : float
         slice width in pixels
-     """
-     kernel_beta = astropy.convolution.Box1DKernel(beta_width)
+    """
+    kernel_beta = astropy.convolution.Box1DKernel(beta_width)
+    webbpsf.webbpsf_core._log.info(f'  MRS empirical broadening: alpha width {alpha_width}, beta width {beta_width}')
 
     # TODO: extend algorithm to handle the datacube case
 
-     if alpha_width is None:
-         psf_model_alpha_beta = np.apply_along_axis(lambda m: convolve(m, kernel_beta), axis=0, arr=psf_model)
-     else:
-         kernel_alpha = astropy.convolution.Gaussian1DKernel(stddev=alpha_width)
-         psf_model_alpha = np.apply_along_axis(lambda m: convolve(m, kernel_alpha), axis=1, arr=psf_model)
-         psf_model_alpha_beta = np.apply_along_axis(lambda m: convolve(m, kernel_beta), axis=0, arr=psf_model_alpha)
-     return psf_model_alpha_beta
+    if alpha_width is None:
+        psf_model_alpha_beta = np.apply_along_axis(lambda m: convolve(m, kernel_beta), axis=0, arr=psf_model)
+    else:
+        kernel_alpha = astropy.convolution.Gaussian1DKernel(stddev=alpha_width)
+        psf_model_alpha = np.apply_along_axis(lambda m: convolve(m, kernel_alpha), axis=1, arr=psf_model)
+        psf_model_alpha_beta = np.apply_along_axis(lambda m: convolve(m, kernel_beta), axis=0, arr=psf_model_alpha)
+
+    return psf_model_alpha_beta
 
 
 def get_mrs_cruciform_amplitude(wavelen):
-    """
-    Empirical amplitude of additional cruciform component in MIRI IFU data
-    wavelen: wavelength (only applicable if wavelength < 7.5 um - see apply_miri_ifu_broadening)
+    """ Calculate empirical amplitude of additional cruciform component in MIRI IFU data
+    See Patapis et al. 2025
+
+    Parameters
+    ----------
+    wavelen : float
+        wavelength (only applicable if wavelength < 7.5 um - see apply_miri_ifu_broadening)
     """
     return -0.16765378 * wavelen + 1.23632423  # Patapis 2025 PSF paper
 
 
 def _round_up_to_odd_integer(value):
+    """ ensure an integer is odd.
+    Minor utility function used by convolution kernel creation"""
     i = np.ceil(value)
     if i % 2 == 0:
         return i + 1
@@ -720,8 +735,8 @@ def _round_up_to_odd_integer(value):
 
 
 def _Lorentz1DKernel(amp, fwhm, x_0):
-    """
-    1D Lorentz model as a convolution kernel
+    """ 1D Lorentz model as an astropy convolution kernel
+
     x_size : size of kernel, should be odd
     """
     if amp is None:
@@ -733,8 +748,9 @@ def _Lorentz1DKernel(amp, fwhm, x_0):
 
 
 def _miri_mrs_empirical_cruciform(psf_model, amp, fwhm, x_0):
-    """
-    Perform the broadening of a psf model in alpha and beta
+    """ Perform the broadening of a psf model in alpha and beta for the cruciform.
+     This implements the additional effect of the cruciform on MRS data.
+     See also _miri_mrs_empirical_broadening
 
     Parameters
     -----------

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -602,6 +602,21 @@ def apply_miri_ifu_broadening(hdulist, options, slice_width=0.196):
         beta_width = slice_width / pixelscl
         alpha_width = _miri_mrs_analytical_sigma_alpha_broadening(wavelen * 1e6) / pixelscl
         out = _miri_mrs_empirical_broadening(psf_model=hdulist[ext].data, alpha_width=alpha_width, beta_width=beta_width)
+    elif model_type.lower() == 'cruciform':
+        # Model based on empirical PSF properties, Argryiou et al.
+        pixelscl = float(hdulist[ext].header['PIXELSCL'])
+        wavelen = float(hdulist[ext].header['WAVELEN'])
+
+        beta_width = slice_width / pixelscl
+        alpha_width = _miri_mrs_analytical_sigma_alpha_broadening(wavelen * 1e6) / pixelscl
+        out = _miri_mrs_empirical_broadening(psf_model=hdulist[ext].data, alpha_width=alpha_width, beta_width=beta_width)
+        if wavelen * 1e6 <= 7.5:
+            amplitude_cruciform = get_mrs_cruciform_amplitude(wavelen * 1e6)
+            oversample_factor = hdulist[ext].header['DET_SAMP']/7  # optimised parameters with oversampling = 7
+            fwhm_cruciform = constants.INSTRUMENT_IFU_BROADENING_PARAMETERS["MIRI"]["fhwm_cruciform"]*oversample_factor
+            offset_cruciform = constants.INSTRUMENT_IFU_BROADENING_PARAMETERS["MIRI"]["offset_cruciform"]*oversample_factor
+            out = _miri_mrs_empirical_cruciform(psf_model=out, amp=amplitude_cruciform,
+                                                fwhm=fwhm_cruciform, x_0=offset_cruciform)
 
     hdulist[ext].data = out
 
@@ -679,3 +694,54 @@ def _miri_mrs_empirical_broadening(psf_model, alpha_width, beta_width):
          psf_model_alpha = np.apply_along_axis(lambda m: convolve(m, kernel_alpha), axis=1, arr=psf_model)
          psf_model_alpha_beta = np.apply_along_axis(lambda m: convolve(m, kernel_beta), axis=0, arr=psf_model_alpha)
      return psf_model_alpha_beta
+
+
+def get_mrs_cruciform_amplitude(wavelen):
+    """
+    Empirical amplitude of additional cruciform component in MIRI IFU data
+    wavelen: wavelength (only applicable if wavelength < 7.5 um - see apply_miri_ifu_broadening)
+    """
+    return -0.16765378*wavelen + 1.23632423  # Patapis 2025 PSF paper
+
+
+def _round_up_to_odd_integer(value):
+    i = np.ceil(value)
+    if i % 2 == 0:
+        return i + 1
+    else:
+        return i
+
+
+def _Lorentz1DKernel(amp, fwhm, x_0):
+    """
+    1D Lorentz model as a convolution kernel
+    x_size : size of kernel, should be odd
+    """
+    if amp is None:
+        amp = 2 / (np.pi * fwhm)
+
+    fwhm_int = _round_up_to_odd_integer(fwhm)
+    return astropy.convolution.Model1DKernel(astropy.modeling.models.Lorentz1D(amplitude=amp, fwhm=fwhm, x_0=x_0),
+                                             x_size=int(8 * fwhm_int + 1))
+
+
+def _miri_mrs_empirical_cruciform(psf_model, amp, fwhm, x_0):
+    """
+    Perform the broadening of a psf model in alpha and beta
+
+    Parameters
+    -----------
+    psf_model : ndarray
+       webbpsf output results, either monochromatic model or datacube
+    amp : float
+       amplitude of Lorentzian in pixels
+    fwhm : float
+       Full Width Half Max of Lorentzian in pixels
+   x_0 : float
+       offset of Lorentzian in pixels
+    """
+    kernel_cruciform = _Lorentz1DKernel(1.0, fwhm, x_0)
+
+    # TODO: extend algorithm to handle the datacube case
+    psf_model_cruciform = np.apply_along_axis(lambda m: convolve(m, kernel_cruciform), axis=1, arr=psf_model)
+    return psf_model+amp*psf_model_cruciform

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -584,7 +584,7 @@ def apply_miri_ifu_broadening(hdulist, options, slice_width=0.196):
     """
     # First, check an optional flag to see whether or not to include this effect.
     # User can set the option to None to disable this step.
-    model_type = options.get('ifu_broadening', 'empirical')
+    model_type = options.get('ifu_broadening', 'empirical_cruciform')
 
     if model_type is None or model_type.lower() == 'none':
         return hdulist
@@ -610,7 +610,8 @@ def apply_miri_ifu_broadening(hdulist, options, slice_width=0.196):
         beta_width = slice_width / pixelscl
         alpha_width = _miri_mrs_analytical_sigma_alpha_broadening(wavelen * 1e6) / pixelscl
         out = _miri_mrs_empirical_broadening(psf_model=hdulist[ext].data, alpha_width=alpha_width, beta_width=beta_width)
-    elif model_type.lower() == 'cruciform':
+    elif model_type.lower() == 'empirical_cruciform':
+        # The above empirical mode, plus an additional cruciform effect at < 7.5 microns
         # Model based on empirical PSF properties, Argryiou et al.
         pixelscl = float(hdulist[ext].header['PIXELSCL'])
         wavelen = float(hdulist[ext].header['WAVELEN'])

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -613,7 +613,7 @@ def apply_miri_ifu_broadening(hdulist, options, slice_width=0.196):
         if wavelen * 1e6 <= 7.5:
             amplitude_cruciform = get_mrs_cruciform_amplitude(wavelen * 1e6)
             oversample_factor = hdulist[ext].header['DET_SAMP']/7  # optimised parameters with oversampling = 7
-            fwhm_cruciform = constants.INSTRUMENT_IFU_BROADENING_PARAMETERS["MIRI"]["fhwm_cruciform"]*oversample_factor
+            fwhm_cruciform = constants.INSTRUMENT_IFU_BROADENING_PARAMETERS["MIRI"]["fwhm_cruciform"]*oversample_factor
             offset_cruciform = constants.INSTRUMENT_IFU_BROADENING_PARAMETERS["MIRI"]["offset_cruciform"]*oversample_factor
             out = _miri_mrs_empirical_cruciform(psf_model=out, amp=amplitude_cruciform,
                                                 fwhm=fwhm_cruciform, x_0=offset_cruciform)

--- a/stpsf/match_data.py
+++ b/stpsf/match_data.py
@@ -1,4 +1,5 @@
 # Functions to match or fit PSFs to observed JWST data
+import warnings
 import astropy
 import astropy.io.fits as fits
 import pysiaf
@@ -78,8 +79,23 @@ def setup_sim_to_match_file(filename_or_HDUList, verbose=True, plot=False, choic
     elif inst.name == 'MIRI':
         if header['EXP_TYPE'] == 'MIR_MRS':
             ch = header['CHANNEL']
+            band = header['BAND']
+            inferred_output_type, inferred_coord_system = infer_mrs_cube_type(filename_or_HDUList)
+            if band == 'MULTIPLE' or inferred_output_type != 'band':
+                warnings.warn(f"** The input file seems to be an MRS datacube with output_type='{inferred_output_type}', "
+                               "combining multiple bands. Note that PSF models can be computed for only 1 band at a time. "
+                               "You will need to make multiple PSF simulations to model the PSF in this dataset. For high "
+                               "precision work, be aware of the small (<1 deg) rotation differences between the individual bands. **")
+                band = 'SHORT' # just pick one, arbitrarily
+            if inferred_coord_system != 'ifualign':
+                warnings.warn(f"** The input file seems to be an MRS datacube with coord_system='skyalign'. Note that PSF "
+                               "models can be computed only for coord_system='ifualign'.. You will need to either re-reduce "
+                               "your data using the ifualign coord_system (preferred) or rotate the PSF model based on the "
+                               "position angle (less preferred, due to numerical interpolation noise). **")
             band_lookup = {'SHORT': 'A', 'MEDIUM': 'B', 'LONG': 'C'}
-            inst.band = str(ch) + band_lookup[header['BAND']]
+            inst.band = str(ch) + band_lookup[band]
+
+
 
         elif inst.filter in ['F1065C', 'F1140C', 'F1550C']:
             inst.image_mask = 'FQPM' + inst.filter[1:5]
@@ -228,3 +244,36 @@ def get_nrc_coron_mask_from_pps_apername(apname_pps):
             image_mask = image_mask[:-1]
 
     return image_mask
+
+def infer_mrs_cube_type(filename, verbose=False):
+    """attempt to infer cube coordinate system and output type from header metadata.
+    The cube_build step doesn't record in metadata several of its key input parameters; this function attempts to infer what their values were.
+
+    Returns (guessed_output_type, guessed_coord_system)
+    """
+    with fits.open(filename) as hdul:
+
+        if hdul[0].header['INSTRUME'] != 'MIRI':
+            raise RuntimeError("This function only applies to MIRI MRS data")
+
+        naxis3 = hdul['SCI'].header['NAXIS3']
+        # Infer cube output type, based on the number of wavelengths in this cube.
+        # This is inelegant but seems to work sufficiently
+        if naxis3 < 2000:
+            output_type = 'band'
+        elif naxis3 > 2000 and naxis3 < 4000:
+            output_type = 'channel'
+        elif naxis3 > 4000:
+            output_type = 'multi'
+
+        # Infer coordinate system, based on PC rotation matrix (?)
+        pc11 = hdul['SCI'].header['PC1_1']
+        pc22 = hdul['SCI'].header['PC2_2']
+        if pc11 == -1 and pc22 == 1:
+            coord_system = 'skyalign'
+        else:
+            coord_system = 'ifualign'
+
+        if verbose:
+            print(filename, naxis3, output_type, pc11, pc22, coord_system)
+    return output_type, coord_system

--- a/stpsf/match_data.py
+++ b/stpsf/match_data.py
@@ -83,15 +83,16 @@ def setup_sim_to_match_file(filename_or_HDUList, verbose=True, plot=False, choic
             inferred_output_type, inferred_coord_system = infer_mrs_cube_type(filename_or_HDUList)
             if band == 'MULTIPLE' or inferred_output_type != 'band':
                 warnings.warn(f"** The input file seems to be an MRS datacube with output_type='{inferred_output_type}', "
-                               "combining multiple bands. Note that PSF models can be computed for only 1 band at a time. "
-                               "You will need to make multiple PSF simulations to model the PSF in this dataset. For high "
-                               "precision work, be aware of the small (<1 deg) rotation differences between the individual bands. **")
-                band = 'SHORT' # just pick one, arbitrarily
+                              "combining multiple bands. Note that PSF models can be computed for only 1 band at a time. "
+                              "You will need to make multiple PSF simulations to model the PSF in this dataset. For high "
+                              "precision work, be aware of the small (<1 deg) rotation differences between the individual"
+                              "bands. **")
+                band = 'SHORT'  # just pick one, arbitrarily
             if inferred_coord_system != 'ifualign':
                 warnings.warn(f"** The input file seems to be an MRS datacube with coord_system='skyalign'. Note that PSF "
-                               "models can be computed only for coord_system='ifualign'.. You will need to either re-reduce "
-                               "your data using the ifualign coord_system (preferred) or rotate the PSF model based on the "
-                               "position angle (less preferred, due to numerical interpolation noise). **")
+                              "models can be computed only for coord_system='ifualign'.. You will need to either re-reduce "
+                              "your data using the ifualign coord_system (preferred) or rotate the PSF model based on the "
+                              "position angle (less preferred, due to numerical interpolation noise). **")
             band_lookup = {'SHORT': 'A', 'MEDIUM': 'B', 'LONG': 'C'}
             inst.band = str(ch) + band_lookup[band]
 
@@ -245,9 +246,11 @@ def get_nrc_coron_mask_from_pps_apername(apname_pps):
 
     return image_mask
 
+
 def infer_mrs_cube_type(filename, verbose=False):
     """attempt to infer cube coordinate system and output type from header metadata.
-    The cube_build step doesn't record in metadata several of its key input parameters; this function attempts to infer what their values were.
+    The cube_build step doesn't record in metadata several of its key input parameters;
+    this function attempts to infer what their values were.
 
     Returns (guessed_output_type, guessed_coord_system)
     """

--- a/stpsf/opds.py
+++ b/stpsf/opds.py
@@ -1765,7 +1765,14 @@ class OTE_Linear_Model_WSS(OPD):
             y_field_pt = np.clip(y_field_pt0, min_y_field, max_y_field)
 
             clip_dist = np.sqrt((x_field_pt - x_field_pt0) ** 2 + (y_field_pt - y_field_pt0) ** 2)
-            if clip_dist > 0.1 * u.arcsec:
+
+            # special case for MIRI: don't do the following warning specifically for the MRS field point since it's
+            # a known issue that # point is slightly outside of the valid region. This specific case is benign and
+            # it's not helpful to emit this warning for every MRS calculation ever
+            mrs_v2v3 = [-8.39108833, -5.32144667]*u.arcmin
+            is_mrs_fieldpoint = np.allclose(v2v3, mrs_v2v3, atol=0.01)
+
+            if (clip_dist > 0.1 * u.arcsec) and not is_mrs_fieldpoint:
                 # warn the user we're making an adjustment here (but no need to do so if the distance is trivially small)
                 warning_message = (
                     f'For (V2,V3) = {v2v3}, Field point {x_field_pt}, {y_field_pt} '

--- a/stpsf/opds.py
+++ b/stpsf/opds.py
@@ -1769,7 +1769,7 @@ class OTE_Linear_Model_WSS(OPD):
             # special case for MIRI: don't do the following warning specifically for the MRS field point since it's
             # a known issue that # point is slightly outside of the valid region. This specific case is benign and
             # it's not helpful to emit this warning for every MRS calculation ever
-            mrs_v2v3 = [-8.39108833, -5.32144667]*u.arcmin
+            mrs_v2v3 = [-8.39108833, -5.32144667] * u.arcmin
             is_mrs_fieldpoint = np.allclose(v2v3, mrs_v2v3, atol=0.01)
 
             if (clip_dist > 0.1 * u.arcsec) and not is_mrs_fieldpoint:

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -1286,7 +1286,7 @@ class JWInstrument(SpaceTelescopeInstrument):
                         # slit type aperture, specifically LRS SLIT, does not have distortion polynomials
                         # therefore omit apply_distortion if a SLIT aperture is selected.
                         psf_siaf = result
-                    psf_siaf_rot = detectors.apply_miri_scattering(psf_siaf)  # apply scattering effect
+                    psf_siaf_rot = detectors.apply_miri_imager_cruciform(psf_siaf)  # apply scattering effect
                     psf_distorted = detectors.apply_detector_charge_diffusion(
                         psf_siaf_rot, options
                     )  # apply detector charge transfer model

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -1278,10 +1278,11 @@ class JWInstrument(SpaceTelescopeInstrument):
                 )  # apply detector charge transfer model
             elif self.name == 'MIRI':
                 # Apply distortion effects to MIRI psf: Distortion and MIRI Scattering
-                _log.debug('MIRI: Adding optical distortion and Si:As detector internal scattering')
                 if self.mode != 'IFU':
+                    _log.debug('MIRI imager: Adding optical distortion and Si:As detector internal scattering')
                     if self._detector_geom_info.aperture.AperType != 'SLIT':
                         psf_siaf = distortion.apply_distortion(result)  # apply siaf distortion
+                        _log.debug('MIRI: Applied optical distortion based on SIAF parameters')
                     else:
                         # slit type aperture, specifically LRS SLIT, does not have distortion polynomials
                         # therefore omit apply_distortion if a SLIT aperture is selected.
@@ -1291,20 +1292,22 @@ class JWInstrument(SpaceTelescopeInstrument):
                         psf_siaf_rot, options
                     )  # apply detector charge transfer model
                 else:
+                    _log.debug('MIRI MRS: Adding IFU PSF broadening effects.')
                     # there is not yet any distortion calibration for the IFU, and
                     # we don't want to apply charge diffusion directly here
                     psf_distorted = detectors.apply_miri_ifu_broadening(result, options, slice_width=self._ifu_slice_width)
             elif self.name == 'NIRSpec':
                 # Apply distortion effects to NIRSpec psf: Distortion only
                 # (because applying detector effects would only make sense after simulating spectral dispersion)
-                _log.debug('NIRSpec: Adding optical distortion')
                 if self.mode != 'IFU':
+                    _log.debug('NIRSpec: Adding optical distortion and detector charge transfer')
                     psf_siaf = distortion.apply_distortion(result)  # apply siaf distortion model
                     psf_distorted = detectors.apply_detector_charge_diffusion(
                         psf_siaf, options
                     )  # apply detector charge transfer model
 
                 else:
+                    _log.debug('NIRSpec IFU: Adding IFU PSF broadening')
                     # there is not yet any distortion calibration for the IFU.
                     psf_distorted = detectors.apply_nirspec_ifu_broadening(result, options)
 

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -1147,6 +1147,19 @@ class JWInstrument(SpaceTelescopeInstrument):
         except KeyError:
             raise ValueError('Not a valid aperture name for {}: {}'.format(self.name, aperture_name))
 
+    def _get_pixelscale_from_apername(self, apername):
+        """Simple utility function to look up pixelscale from apername"""
+        ap = self.siaf[apername]
+        # Here we make the simplifying assumption of **square** pixels, which is true within 0.5%.
+        # The slight departures from this are handled in the distortion model; see distortion.py
+        return (ap.XSciScale + ap.YSciScale) / 2
+
+    @property
+    def mode(self):
+        # This exists just for API consistency with the subclasses that have an imaging vs IFU mode toggle,
+        # so that all JWST instrument classes have a mode attribute, consistently, whether used or not
+        return "imaging"
+
     def _get_fits_header(self, result, options):
         """populate FITS Header keywords"""
         super(JWInstrument, self)._get_fits_header(result, options)
@@ -1252,7 +1265,9 @@ class JWInstrument(SpaceTelescopeInstrument):
         add_distortion = options.get('add_distortion', True)
         crop_psf = options.get('crop_psf', True)
         # you can turn on/off IPC corrections via the add_ipc option, default True.
-        add_ipc = options.get('add_ipc', True)
+        # except for IFU mode simulations, it doesn't make sense to add the regular detector IPC
+        # instead the more complex IFU broadening models should be applied
+        add_ipc = options.get('add_ipc', True if self.mode != 'IFU' else False)
 
         # Add distortion if set in calc_psf
         if add_distortion:

--- a/stpsf/tests/test_detectors.py
+++ b/stpsf/tests/test_detectors.py
@@ -17,7 +17,7 @@ def test_apply_miri_scattering_error():
 
     # Test that running this function will raise a ValueError
     with pytest.raises(ValueError) as excinfo:
-        detectors.apply_miri_scattering(psf)
+        detectors.apply_miri_imager_cruciform(psf)
     assert 'ValueError' in str(excinfo), 'Non-MIRI PSFs should not be able to run through apply_miri_scattering'
 
 
@@ -45,7 +45,7 @@ def test_apply_miri_scattering():
         psf[ext_new].header['EXTNAME'] = psf[ext].header['EXTNAME'][0:4] + 'DIST'  # change extension name
 
     # Run it through just the apply_miri_scattering function
-    psf_cross = detectors.apply_miri_scattering(psf)
+    psf_cross = detectors.apply_miri_imager_cruciform(psf)
 
     # Rebin data to get 3rd extension
     mir.options['output_mode'] = 'Both extensions'
@@ -137,7 +137,7 @@ def test_miri_conservation_energy():
         psf[ext_new].header['EXTNAME'] = psf[ext].header['EXTNAME'][0:4] + 'DIST'  # change extension name
 
     # Run it through just the apply_miri_scattering function
-    psf_cross = detectors.apply_miri_scattering(psf)
+    psf_cross = detectors.apply_miri_imager_cruciform(psf)
 
     # Rebin data to get 3rd extension
     mir.options['output_mode'] = 'Both extensions'

--- a/stpsf/tests/test_miri.py
+++ b/stpsf/tests/test_miri.py
@@ -243,7 +243,10 @@ def test_miri_ifu_broadening():
     fwhm_detdist = stpsf.measure_fwhm(psf, ext='DET_DIST')
     assert fwhm_overdist > fwhm_oversamp, "IFU broadening model should increase the FWHM for the distorted extensions"
 
-    assert np.isclose(psf['DET_SAMP'].data.sum(), psf['DET_DIST'].data.sum(), rtol=5e-3), "IFU broadening should not change total flux much"
+    # test flux conservation. THis is close but not exact, due to the optical distortion part which is distinct from but
+    # happens at same point in the calculation as the IFU broadening effect.
+    assert np.isclose(psf['DET_SAMP'].data.sum(), psf['DET_DIST'].data.sum(), rtol=2e-4), "IFU broadening should not change total flux much"
+
 
     # Now test that we can also optionally turn off that effect
     miri.options['ifu_broadening'] = None
@@ -253,3 +256,8 @@ def test_miri_ifu_broadening():
     fwhm_overdist = stpsf.measure_fwhm(psf_nb, ext='OVERDIST')
     # The PSF will still be a little broader in this case due to the IPC model, but not by a lot..
     assert fwhm_oversamp < fwhm_overdist <= 1.1 * fwhm_oversamp, "IFU broadening model should be disabled for this test case"
+
+    # test flux conservation with and without the IFU broadening. This should be a more exact match
+    assert np.isclose(psf_nb['DET_DIST'].data.sum(), psf['DET_DIST'].data.sum() ), "IFU broadening should not change total flux much"
+
+

--- a/stpsf/tests/test_miri.py
+++ b/stpsf/tests/test_miri.py
@@ -233,7 +233,7 @@ def test_miri_ifu_broadening():
 
     miri = stpsf_core.MIRI()
     miri.mode = 'IFU'
-    psf = miri.calc_psf(monochromatic=2.8e-6, fov_pixels=10)
+    psf = miri.calc_psf(monochromatic=6.8e-6, fov_pixels=20)
 
     fwhm_oversamp = stpsf.measure_fwhm(psf, ext='OVERSAMP')
     fwhm_overdist = stpsf.measure_fwhm(psf, ext='OVERDIST')
@@ -242,6 +242,8 @@ def test_miri_ifu_broadening():
     fwhm_detsamp = stpsf.measure_fwhm(psf, ext='DET_SAMP')
     fwhm_detdist = stpsf.measure_fwhm(psf, ext='DET_DIST')
     assert fwhm_overdist > fwhm_oversamp, "IFU broadening model should increase the FWHM for the distorted extensions"
+
+    assert np.isclose(psf['DET_SAMP'].data.sum(), psf['DET_DIST'].data.sum(), rtol=5e-3), "IFU broadening should not change total flux much"
 
     # Now test that we can also optionally turn off that effect
     miri.options['ifu_broadening'] = None

--- a/stpsf/tests/test_miri.py
+++ b/stpsf/tests/test_miri.py
@@ -245,17 +245,17 @@ def test_miri_ifu_broadening():
 
     # test flux conservation. THis is close but not exact, due to the optical distortion part which is distinct from but
     # happens at same point in the calculation as the IFU broadening effect.
-    assert np.isclose(psf['DET_SAMP'].data.sum(), psf['DET_DIST'].data.sum(), rtol=2e-4), "IFU broadening should not change total flux much"
+    assert np.isclose(psf['DET_SAMP'].data.sum(), psf['DET_DIST'].data.sum()), "IFU broadening should not change total flux much"
 
 
     # Now test that we can also optionally turn off that effect
     miri.options['ifu_broadening'] = None
-    psf_nb = miri.calc_psf(monochromatic=2.8e-6, fov_pixels=10)
+    psf_nb = miri.calc_psf(monochromatic=6.8e-6, fov_pixels=20)
 
     fwhm_oversamp = stpsf.measure_fwhm(psf_nb, ext='OVERSAMP')
     fwhm_overdist = stpsf.measure_fwhm(psf_nb, ext='OVERDIST')
     # The PSF will still be a little broader in this case due to the IPC model, but not by a lot..
-    assert fwhm_oversamp < fwhm_overdist <= 1.1 * fwhm_oversamp, "IFU broadening model should be disabled for this test case"
+    assert fwhm_overdist == fwhm_oversamp, "IFU broadening model should be disabled for this test case"
 
     # test flux conservation with and without the IFU broadening. This should be a more exact match
     assert np.isclose(psf_nb['DET_DIST'].data.sum(), psf['DET_DIST'].data.sum() ), "IFU broadening should not change total flux much"

--- a/stpsf/utils.py
+++ b/stpsf/utils.py
@@ -1118,3 +1118,17 @@ def get_target_phase_map_filename(apername):
         not found under {}.".format(apername.split('_')[1].lower(),path))
 
     return was_targ_file
+
+
+def display_psf_exts(psf, figsize=(12,3), imagecrop=5, colorbar=False, **kwargs):
+    """ Display all extensions of a given PSF.
+
+    See display_psf for additional information on parameters.
+    """
+    import poppy
+    n_exts = len(psf)
+
+    fig, axes = plt.subplots(figsize=figsize, ncols=4)
+    for ext in range(n_exts):
+        poppy.display_psf(psf, ext=ext, ax=axes[ext], title=f'Ext {ext}: {psf[ext].header["EXTNAME"]}',
+                           imagecrop=imagecrop, colorbar=colorbar, **kwargs)


### PR DESCRIPTION
**[Relocated from https://github.com/spacetelescope/webbpsf/pull/930]**

_Cloned from #928, and relocated into a PR branch owned by @mperrin.  As noted in #928, the workflow for this one is atypical in that @patapisp started the branch and I @mperrin am now picking up to revise and finish it. By @patapisp:_

This is the the start of a PR for finalising the broadening and cruciform implementation for the MIRI IFU mode. Added an additional option for ```model_type = "cruciform"```

Remaining tasks: 

- [x] check normalisation convention when modifying PSF models
- [ ] changing the ```oversample``` parameter yields quite significant differences in the PSF models
- [ ] switch empirical broadening (now following Law+2023) to broadening due to sampling by detector and cube pixels


![image](https://github.com/user-attachments/assets/49c8fd09-cda7-4906-918b-6df9dcc8574c)
