### PR TITLE
Update readthedocs for webbpsf_to_stpsf notebook

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,6 @@
 Documentation for STPSF
 ===============================
-
-**(Formerly WebbPSF, for versions < 2.0)**
+`(Formerly WebbPSF, for versions < 2.0) <webbpsf_to_stpsf.ipynb>`_
 
 STPSF is a Python package that computes simulated point spread functions (PSFs) for NASA's James Webb Space Telescope (JWST) and Nancy Grace Roman Space Telescope. STPSF transforms models of telescope and instrument optical state into PSFs, taking into account detector pixel scales, rotations, filter profiles, and point source spectra. It is rather a tool for transforming optical path difference (OPD) maps, created with observatory systems engineering models, into the resulting PSFs as observed with JWST's or Roman's instruments.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,6 +81,7 @@ Contents
    :caption: Package Documentation
 
    api_reference.rst
+   webbpsf_to_stpsf.ipynb
    help.rst
    sampling.rst
    fft_optimization.rst

--- a/docs/webbpsf_to_stpsf.ipynb
+++ b/docs/webbpsf_to_stpsf.ipynb
@@ -76,7 +76,7 @@
    "id": "63bae68e-7d58-4afc-9b83-18887c209611",
    "metadata": {},
    "source": [
-    "# import stpsf"
+    "#### import stpsf"
    ]
   },
   {
@@ -198,8 +198,7 @@
    "id": "cc9e0ccc-c724-41f0-a541-cf4ffc29b85a",
    "metadata": {},
    "source": [
-    "<a id=\"import_stpsf_as_webbpsf\"></a> \n",
-    "# import stpsf as webbpsf"
+    "#### import stpsf as webbpsf"
    ]
   },
   {

--- a/docs/webbpsf_to_stpsf.ipynb
+++ b/docs/webbpsf_to_stpsf.ipynb
@@ -57,6 +57,7 @@
    "source": [
     "#### Updating CI/Code/Environment References:\n",
     "- Update any references to `$WEBBPSF_PATH` with `$STPSF_PATH`\n",
+    "\n",
     "#### Extracted Information Location:\n",
     "- Extracted information is now stored in: /stpsf-data\n",
     "\n",


### PR DESCRIPTION
Update the webbpsf_to_stpsf to not contain the header error
Include webbpsf_to_stpsf as subheader link at top of index page
Include Webbpsf_to_stpsf on left side index
See yellow circles:
<img width="1131" alt="Screenshot 2025-02-11 at 9 56 29 AM" src="https://github.com/user-attachments/assets/c4017540-5bfb-4881-a8d8-d5925b1b760b" />

