### PR TITLE
Fix NIRISS bug by adding conditional statement to handle PUPIL filters 

### DIFF
--- a/stpsf/match_data.py
+++ b/stpsf/match_data.py
@@ -44,7 +44,8 @@ def setup_sim_to_match_file(filename_or_HDUList, verbose=True, plot=False, choic
         # Grab the filter name from the PUPIL keyword in this case.
         inst.filter = header['PUPIL']
     elif (inst.name == 'NIRISS') and (header['FILTER'] == 'CLEAR'):
-        # For NIRISS, 6 out of 12 filters are in the pupil wheel. [S. T. Sohn Feb 13, 2025]
+        # For NIRISS, 6 out of 12 filters are in the pupil wheel, which mean if FILTER=CLEAR,
+        # PUPIL keyword will point to the actual filter. [S. T. Sohn Feb 13, 2025]
         inst.filter = header['PUPIL']
     else:
         inst.filter = header['filter']

--- a/stpsf/match_data.py
+++ b/stpsf/match_data.py
@@ -43,6 +43,9 @@ def setup_sim_to_match_file(filename_or_HDUList, verbose=True, plot=False, choic
         # These NIRCam filters are physically in the pupil wheel, but still act as filters.
         # Grab the filter name from the PUPIL keyword in this case.
         inst.filter = header['PUPIL']
+    elif (inst.name == 'NIRISS') and (header['FILTER'] == 'CLEAR'):
+        # For NIRISS, 6 out of 12 filters are in the pupil wheel. [S. T. Sohn Feb 13, 2025]
+        inst.filter = header['PUPIL']
     else:
         inst.filter = header['filter']
     inst.set_position_from_aperture_name(header['APERNAME'])


### PR DESCRIPTION
Added a conditional statement in `match_data.py` for NIRISS.

NIRISS filters are actually in both the filter and pupil wheels. When FILTER=CLEAR, the filter is in the PUPIL wheel. Code has been tested on a few NIRISS images. Before the fix, `setup_sim_to_match_file` was incorrectly assuming Pupil plane mask = GR700XD for observations using FILTER=CLEAR / PUPIL=F090W (or any other filter). After the fix, I confirmed that the code identifies the correct filter.