### PR TITLE
Change Roman detector naming to support WFIxy 

### DIFF
--- a/stpsf/distortion.py
+++ b/stpsf/distortion.py
@@ -125,7 +125,7 @@ def distort_image(
         instrument = hdu_list[0].header['INSTRUME'].upper().strip()
 
         if instrument == 'WFI':
-            aper_name = 'WFI' + hdu_list[0].header['DETECTOR'][-2:] + '_FULL'
+            aper_name = hdu_list[0].header['DETECTOR'] + '_FULL'
         else:
             aper_name = hdu_list[0].header['APERNAME'].upper()
 
@@ -246,7 +246,7 @@ def apply_distortion(hdulist_or_filename=None, fill_value=0):
     # Log instrument and detector names
     instrument = hdu_list[0].header['INSTRUME'].upper().strip()
     if instrument == 'WFI':
-        aper_name = 'WFI' + hdu_list[0].header['DETECTOR'][-2:] + '_FULL'
+        aper_name = hdu_list[0].header['DETECTOR'] + '_FULL'
     else:
         aper_name = hdu_list[0].header['APERNAME'].upper()
 
@@ -315,7 +315,7 @@ def apply_rotation(hdulist_or_filename=None, rotate_value=None, crop=True):
     # Log instrument and detector names
     instrument = hdu_list[0].header['INSTRUME'].upper().strip()
     if instrument == 'WFI':
-        aper_name = 'WFI' + hdu_list[0].header['DETECTOR'][-2:] + '_FULL'
+        aper_name = hdu_list[0].header['DETECTOR'] + '_FULL'
     else:
         aper_name = hdu_list[0].header['APERNAME'].upper()
 

--- a/stpsf/gridded_library.py
+++ b/stpsf/gridded_library.py
@@ -308,7 +308,8 @@ class CreatePSFLibrary:
         model_list = []
         for k, det in enumerate(self.detector_list):
             if self.verbose is True:
-                print('  Running detector: {}'.format(det))
+                print_det = det.replace("SCA", "WFI") if self.instr.upper() == "WFI" else det
+                print('  Running detector: {}'.format(print_det))
 
             # Create an array to fill ([i, y, x])
             psf_size = self.fov_pixels * self.oversample
@@ -359,7 +360,10 @@ class CreatePSFLibrary:
             meta = OrderedDict()
 
             meta['INSTRUME'] = (self.instr, 'Instrument name')
-            meta['DETECTOR'] = (det, 'Detector name')
+            if self.instr.upper() == 'WFI':
+                meta['DETECTOR'] = (det.replace("SCA", "WFI"), 'Detector name')
+            else:
+                meta['DETECTOR'] = (det, 'Detector name')
             meta['FILTER'] = (self.filter, 'Filter name')
             meta['PUPILOPD'] = (psf[ext].header['PUPILOPD'], 'Pupil OPD source name')
             meta['OPD_FILE'] = (psf[ext].header['OPD_FILE'], 'Pupil OPD file name')

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -374,7 +374,11 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
         super()._get_fits_header(result, options)
         result[0].header['DETXPIXL'] = (self.detector_position[0], 'X pixel position (for field dependent aberrations)')
         result[0].header['DETYPIXL'] = (self.detector_position[1], 'Y pixel position (for field dependent aberrations)')
-        result[0].header['DETECTOR'] = (self.detector, 'Detector selected')
+
+        if self.telescope == 'Roman':
+            result[0].header['DETECTOR'] = (self.detector.replace("SCA", "WFI"), 'Detector selected')
+        else:
+            result[0].header['DETECTOR'] = (self.detector, 'Detector selected')
 
     def _calc_psf_format_output(self, result, options):
         """
@@ -739,6 +743,11 @@ class WFI(RomanInstrument):
         """
         The current WFI detector. See WFI.detector_list for valid values.
         """
+
+        
+        if value.startswith("WFI"):
+            # Allow users to input detector names as WFIxy; this is then changed to SCAxy for backward compatibility.
+            value = "SCA" + value[-2:]
         if value.upper() not in self.detector_list:
             raise ValueError('Invalid detector. Valid detector names are: {}'.format(', '.join(self.detector_list)))
 

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -355,7 +355,10 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         result[0].header['VERSION'] = (version, 'STPSF software version')
         result[0].header['DATAVERS'] = (self._data_version, 'STPSF reference data files version')
 
-        result[0].header['DET_NAME'] = (self.detector, 'Name of detector on this instrument')
+        if self.telescope == 'Roman':
+            result[0].header['DET_NAME'] = (self.detector.replace("SCA", "WFI"), 'Name of detector on this instrument')
+        else:
+            result[0].header['DET_NAME'] = (self.detector, 'Name of detector on this instrument')
 
         # Correct detector pixel coordinates to allow for even arrays to be centered on half pixel boundary
         dpos = np.asarray(self.detector_position, dtype=float)


### PR DESCRIPTION
This PR addresses https://github.com/spacetelescope/stpsf/issues/3

Given that much of the underlying data files (pupils, zernikes) and implementation relies on detector naming containing SCA, the proposed implementation allows for users to specify any detector with the "WFIxy" string using the detector setter, which then gets converted back to SCA for internal and backward compatibility. 

Note that the header information as well as some verbose statements are also being updated to specify WFIxy.