### PR TITLE
removing the filter keyword in tar extractall

### DIFF
--- a/stpsf/utils.py
+++ b/stpsf/utils.py
@@ -205,7 +205,7 @@ def auto_download_stpsf_data():
 
             # Extract the tarball
             with tarfile.open(filename, "r:gz") as tar:
-                tar.extractall(default_path.parent, filter="fully_trusted")
+                tar.extractall(default_path.parent)
 
         if not any(default_path.iterdir()):
             raise IOError(f"Failed to get and extract STPSF data files to {default_path}")

--- a/stpsf/utils.py
+++ b/stpsf/utils.py
@@ -206,6 +206,8 @@ def auto_download_stpsf_data():
             # Extract the tarball
             with tarfile.open(filename, "r:gz") as tar:
                 tar.extractall(default_path.parent)
+	# TODO filter="fully_trusted" will need to be added as a parameter once python 3.14
+	# is adopted due to advertised changing defaults in python.
 
         if not any(default_path.iterdir()):
             raise IOError(f"Failed to get and extract STPSF data files to {default_path}")


### PR DESCRIPTION
This  is a small change to address issue #79 
By removing the keyword filter, then it uses the default value for the filter, None, which for versions of Python +3.10.12 it equivalent to 'fully_trusted' 
See 
https://docs.python.org/3.10/library/tarfile.html#extraction-filters