### PR TITLE
Roman: Update SIAF aperturename and pixel scale based on detector.

### DIFF
--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -267,6 +267,10 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.siaf = stpsf_core.get_siaf_with_caching('roman')
+        self._aperturename = None
+
         self.options['jitter'] = 'gaussian'
         self.options['jitter_sigma'] = 0.012  # arcsec/axis, see https://roman.ipac.caltech.edu/sims/Param_db.html#telescope
 
@@ -745,6 +749,32 @@ class WFI(RomanInstrument):
         self._detector = value.upper()
         if self._detector is not None:
             self._update_pupil(detector=self._detector)
+        self._update_aperturename()
+
+    def _update_aperturename(self):
+        """Update SIAF aperture name after change in detector or other relevant properties.
+        This function handles just inferring the new value of the aperturename.
+        See the aperturename.setter function for additional changed based on that.
+        """
+        self.aperturename = self._detector.replace('SCA', 'WFI') + "_FULL"
+
+    @RomanInstrument.aperturename.setter
+    def aperturename(self, value):
+        """Set SIAF aperture name to new value, with validation.
+
+        This also updates the pixelscale to the local value for that aperture, for a small precision enhancement.
+        """
+        try:
+            ap = self.siaf[value]
+        except KeyError:
+            raise ValueError(f'Aperture name {value} not a valid SIAF aperture name for {self.name}')
+
+        # Only update if new value is different
+        if self._aperturename != value:
+            self._aperturename = value
+
+            # Update pixelscale based on specified aperture name
+            self.pixelscale = self._get_pixelscale_from_apername(value)
 
     @RomanInstrument.filter.setter
     def filter(self, value):

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -343,6 +343,13 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         """Update SIAF aperture name after change in detector or other relevant properties"""
         self.aperturename = self._detectors[self._detector]
 
+    def _get_pixelscale_from_apername(self, apername):
+        """Simple utility function to look up pixelscale from apername"""
+        ap = self.siaf[apername]
+        # Here we make the simplifying assumption of **square** pixels, which is true within 0.5%.
+        # The slight departures from this are handled in the distortion model; see distortion.py
+        return (ap.XSciScale + ap.YSciScale) / 2
+
     def _get_fits_header(self, result, options):
         """populate FITS Header keywords"""
         super(SpaceTelescopeInstrument, self)._get_fits_header(result, options)
@@ -1139,13 +1146,6 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         except KeyError:
             raise ValueError('Not a valid aperture name for {}: {}'.format(self.name, aperture_name))
-
-    def _get_pixelscale_from_apername(self, apername):
-        """Simple utility function to look up pixelscale from apername"""
-        ap = self.siaf[apername]
-        # Here we make the simplifying assumption of **square** pixels, which is true within 0.5%.
-        # The slight departures from this are handled in the distortion model; see distortion.py
-        return (ap.XSciScale + ap.YSciScale) / 2
 
     def _get_fits_header(self, result, options):
         """populate FITS Header keywords"""

--- a/stpsf/tests/test_roman.py
+++ b/stpsf/tests/test_roman.py
@@ -290,6 +290,20 @@ def test_WFI_limits_interpolation_range():
     )
 
 
+def test_WFI_auto_aperturename_and_pixelscale():
+    wfi = roman.WFI()
+    assert wfi.aperturename == "WFI01_FULL", "Aperture name should match detector"
+    wfi.detector = 'SCA12'
+    assert wfi.aperturename == "WFI12_FULL", "Aperture name should match detector"
+
+
+    aperture = wfi.siaf[wfi.aperturename]
+    assert wfi.pixelscale == (aperture.XSciScale + aperture.YSciScale)/2, "Pixel scale should match the SIAF for that aperturename"
+
+
+# -------- Test functions for the (very limited) Roman Coronagraph implementation below here
+
+
 def test_coronagraph_detector_position():
     """Test existence of the Coronagraph detector position etc, and that you can't set it."""
     cor = roman.RomanCoronagraph()


### PR DESCRIPTION
This small PR makes the Roman WFI implementation more consistent with the JWST instruments, by adding the same machinery for updating SIAF aperture name and pixel scale based on the selected detector.  The aperturename is inferred based on the detector, and the pixel scale is inferred as the average of the XSciScale and YSciScale values in the SIAF for that detector. 

(Currently it appears that the SIAF does not have distinct pixel scales for the WFI SCAs, but presumably it will eventually do so).

```
In [2]: wfi = stpsf.WFI()

In [3]: wfi.aperturename
Out[3]: 'WFI01_FULL'

In [4]: wfi.pixelscale
Out[4]: 0.1078577405

```