### PR TITLE
Roman: Implement calls to detector charge diffusion model. 

### DIFF
--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -388,6 +388,7 @@ INSTRUMENT_DETECTOR_CHARGE_DIFFUSION_DEFAULT_PARAMETERS = {
     'NIRSPEC': 0.036,
     'MIRI': 0.001,  # Fit by Marshall + Marcio to ePSFs, after adding IPC
     #  0.070 Based on user reports, see issue #674. However, this was before adding IPC effects
+    'WFI': 0.0   # Placeholder variable. Needs value update.
 }
 # add Interpixel capacitance (IPC) effects. These are the parameters for each detector kernel
 # For NIRCam we  use CV3/Flight convolution kernels from Jarron Leisenring, see detectors.apply_detector_ipc for details

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -18,7 +18,7 @@ import poppy
 from astropy.io import fits
 from scipy.interpolate import griddata
 
-from . import distortion, utils, stpsf_core
+from . import distortion, utils, stpsf_core, detectors
 
 _log = logging.getLogger('stpsf')
 
@@ -398,7 +398,7 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
         add_distortion = options.get('add_distortion', True)
         # Add distortion if set in calc_psf
         if add_distortion:
-            _log.debug('Adding PSF distortion(s)')
+            _log.info('Adding PSF distortion(s) and detector effects')
 
             # Set up new extensions to add distortion to:
             n_exts = len(result)
@@ -410,7 +410,10 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
                 _log.debug('Appending new extension {} with EXTNAME = {}'.format(ext_new, result[ext_new].header['EXTNAME']))
 
             _log.debug('WFI: Adding optical distortion')
+            # TODO - we may not actually want to include this for WFI. To be confirmed.
             psf_distorted = distortion.apply_distortion(result)  # apply siaf distortion model
+            # apply detector charge transfer model
+            psf_distorted = detectors.apply_detector_charge_diffusion(psf_distorted, options)
 
             # Edit the variable to match if input didn't request distortion
             # (cannot set result = psf_distorted due to return method)


### PR DESCRIPTION
Initial step towards detector charge diffusion effects for Roman. 

This PR updates the Roman WFI model to have the same call to `detectors.apply_detector_charge_diffusion` as is used in the JWST models.   

For now the coefficient for the size of the diffusion effect Gaussian model is set to precisely 0, so this makes no changes in the contents of the PSFs. This just puts in place the infrastructure so that it's ready for use once there's some estimated value. 

