### PR TITLE
[SCSB-205] `project.license.file` -> `project.license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ description = "Creates simulated point spread functions for Space Telescopes (Ja
 authors = [
     { name = "Association of Universities for Research in Astronomy", email = "help@stsci.edu" },
 ]
+license-files = ["LICENSE.md"]
 dynamic = [
     "version",
 ]
@@ -28,9 +29,6 @@ dependencies = [
     "synphot>=1.0.0",
     "astroquery>=0.4.6",
 ]
-
-[project.license]
-file = "LICENSE.md"
 
 [project.optional-dependencies]
 test = [

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,8 @@ conda deps =
     cython
     photutils
     astroquery
+commands_pre=
+    pip list
 commands=
     test: pytest {posargs}
     cov: pytest {posargs} --cov-config=pyproject.toml --cov-report=xml --cov=stpsf stpsf/tests/


### PR DESCRIPTION
the `project.license` entry is changing to just use SPDX expressions; license files are moving to `project.license-files` ([PEP 639](https://peps.python.org/pep-0639/))