### PR TITLE
Adding support for off-nominal phase map sizes 

### DIFF
--- a/stpsf/mast_wss.py
+++ b/stpsf/mast_wss.py
@@ -800,6 +800,7 @@ def _query_program_visit_times_by_inst(program, instrument, verbose=False):
         'NIRCAM': 'Mast.Jwst.Filtered.NIRCam',
         'NIRSPEC': 'Mast.Jwst.Filtered.NIRSpec',
         'NIRISS': 'Mast.Jwst.Filtered.NIRISS',
+        'FGS': 'Mast.Jwst.Filtered.FGS'
     }
 
     service = svc_table[instrument.upper()]

--- a/stpsf/trending.py
+++ b/stpsf/trending.py
@@ -1930,6 +1930,9 @@ def show_wfs_during_program(
     # or use values provided by the user
     sci_duration = science_visit_table['start_mjd'].max() - science_visit_table['start_mjd'].min()
     plot_padding_time_range = max(sci_duration.to(u.day) * 0.2, 4 * u.day)
+    if plot_padding_time_range > 30 * u.day:
+        plot_padding_time_range = 30 * u.day # Avoid a padding larger than 30 days
+
     if start_date is None:
         start_date = science_visit_table['start_mjd'].min() - plot_padding_time_range
     else:
@@ -1938,6 +1941,10 @@ def show_wfs_during_program(
         end_date = science_visit_table['end_mjd'].max() + plot_padding_time_range
     else:
         end_date = astropy.time.Time(end_date)
+
+    min_date = astropy.time.Time('2022-03-14') #Final Alignment
+    if start_date < min_date:
+        start_date = min_date
 
     # Look up wavefront sensing and mirror move corrections for that range
     opdtable = get_opdtable_for_daterange(start_date, end_date)
@@ -1953,6 +1960,14 @@ def show_wfs_during_program(
         except FileNotFoundError:
             stpsf.mast_wss.mast_retrieve_opd(opd_fn, verbose=verbose)
             opd, opd_hdul = stpsf.trending._read_opd(opd_fn)
+
+        if opd.shape != (256, 256):  # handle the case for commissioning phasemaps
+            # the results from the zoom function preserve the STD between both phase maps and
+            # the total sum between the phase maps is proportional to the zoom value
+            # by construction there are no OPDs larger than 256x256
+            print('before, ',opd.shape)
+            opd = scipy.ndimage.zoom(opd, 256 / opd.shape[0])
+            print('after, ',opd.shape)
 
         opds.append(opd)
         wfs_dates.append(opdtable[row_index]['date'])

--- a/stpsf/trending.py
+++ b/stpsf/trending.py
@@ -1965,9 +1965,8 @@ def show_wfs_during_program(
             # the results from the zoom function preserve the STD between both phase maps and
             # the total sum between the phase maps is proportional to the zoom value
             # by construction there are no OPDs larger than 256x256
-            print('before, ',opd.shape)
             opd = scipy.ndimage.zoom(opd, 256 / opd.shape[0])
-            print('after, ',opd.shape)
+
 
         opds.append(opd)
         wfs_dates.append(opdtable[row_index]['date'])


### PR DESCRIPTION
See #85 
This PR adds support for off-nominal phase map sizes, like those during commissioning. 
From this the trending function `show_wfs_during_program` can now show the WFE trending during commissioning programs, for example PID 1163 (initial wavefront maintenance)
`pid = "1163"`
`stpsf.trending.show_wfs_during_program(pid)`

![image](https://github.com/user-attachments/assets/a8ff0c8a-104f-4753-b391-d63ddb013e40)


It also solve the error as describe from the issue, in particular, it allows for a full display of PID 2473 without any issue by using the nominal date ranges. 
`pid = "02473"`
`stpsf.trending.show_wfs_during_program(pid)`

![image](https://github.com/user-attachments/assets/0c9df8f4-dd5d-42a6-a02c-13dedb2200de)

This PR also adds a hard cutoff day for the beginning of trending (the day of fine alignment, OTE-23). It also restric the padding not to be larger than 30 days. This avoid too much padding for programs contain within several JWST science cycles. 
