### PR TITLE
New file for NIRISS NRM pupil geometry

### DIFF
--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -3542,6 +3542,13 @@ class NIRISS(JWInstrument):
 
         # Note - the syntax for specifying shifts is different between FITS files and
         # AnalyticOpticalElement instances. Annoying but historical.
+
+	# Note on NIRISS NRM geometry
+	# The file for the pupil mask MASK_NRM was updated to include 
+	# 0.82 to 0.80 m subaperture flat-to-flat distance. Github issue 76 
+	# The new file, MASK_NRM.fits.gz, is include with  stpsf-data for  >2.0.0v
+	# File provided by  @rcooper295 (02/05/2025)
+ 
         if self.pupil_mask == 'MASK_NRM':
             optsys.add_pupil(
                 transmission=self._datapath + '/optics/MASK_NRM.fits.gz',


### PR DESCRIPTION
This PR just add a note to an update to the mask file for NIRISS NRM, MASK_NRM.fits.gz 
The file will be included in stpsf-data for >2.0.0v
see Issue #76 for details  
Below is a comparison between a  PSF simulation  using the old 0.82m  flat-to-flat distance (left panel), new 0.80m (middle panel) and difference (right panel)
![image](https://github.com/user-attachments/assets/24aacf2e-1bb5-4baa-869c-3cd8e29da3e3)

This is a PSF simulation with the 0.82m NIRISS NRM mask 
![image](https://github.com/user-attachments/assets/6c70aeb7-eebc-4e96-925a-8d83fdc49358)

and with the updated 0.80m, 
![image](https://github.com/user-attachments/assets/a4b83f33-ad66-43c9-bb77-d04e3d664ddd)
