### PR TITLE
#98 - Reference issue in SUR.xmltext()

### DIFF
--- a/stpsf/opds.py
+++ b/stpsf/opds.py
@@ -1870,8 +1870,8 @@ class OTE_Linear_Model_WSS(OPD):
 
         """
 
-        if segment == 'SM':
-            raise ValueError('SM not supported by move_seg_local. Use move_sm_local instead.')
+        if segment == 'SM-19':
+            raise ValueError('SM-19 not supported by move_seg_local. Use move_sm_local instead.')
 
         # Handle tilts and clocking
         tilts = np.array([xtilt, ytilt, clocking], dtype=float)
@@ -2302,7 +2302,7 @@ class OTE_Linear_Model_WSS(OPD):
                     rot_unit = update.units['X_TILT']
                     trans_unit = update.units['X_TRANS']
 
-                    if update.segment == 'SM':
+                    if update.segment == 'SM-19':
                         self.move_sm_local(
                             xtilt=update.moves['X_TILT'] * sign,
                             ytilt=update.moves['Y_TILT'] * sign,

--- a/stpsf/surs.py
+++ b/stpsf/surs.py
@@ -45,7 +45,7 @@ class SegmentUpdate(object):
             # parse from some XML in a SUR file
             self.id = int(xmlnode.attrib['id'])
             self.type = xmlnode.attrib['type']
-            self.segment = xmlnode.attrib['seg_id'][0:2]
+            self.segment = xmlnode.attrib['seg_id']
             self.absolute = xmlnode.attrib['absolute'] == 'true'
             self.coord = xmlnode.attrib['coord']  # local or global
             self.stage_type = xmlnode.attrib['stage_type']  # recenter_fine, fine_only, none

--- a/stpsf/surs.py
+++ b/stpsf/surs.py
@@ -171,7 +171,7 @@ class SUR(object):
     def xmltext(self):
         """The XML text representation of a given move"""
         text = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-                <SEGMENT_UPDATE_REQUEST creator="?" date="{date}" time="{time}" version="0.0.1" operational="false"
+                <SEGMENT_UPDATE_REQUEST creator="?" date="{self.date}" time="{self.time}" version="0.0.1" operational="false"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../setup_files/
                 schema/segment_update_request.xsd">
                 <CONFIGURATION_NAME>{self.configuration_name}</CONFIGURATION_NAME>


### PR DESCRIPTION
#98 

I recently used the SUR.xmltext() function to generate SURs programmatically for JWST WFS&C analysis using TAS data and got a XML schema validation error with the resulting SUR. I determined that the SUR attribute date/time values were missing the reference to self.