### PR TITLE
update mast_wss.query_wfsc_images_latest for cycle 4

### DIFF
--- a/stpsf/mast_wss.py
+++ b/stpsf/mast_wss.py
@@ -644,10 +644,12 @@ def query_wfsc_images_by_program(prog, obs, detector='NRCA3', productlevel=3):
     return tab
 
 
-def query_wfsc_images_latest(detector='NRCA3', productlevel=3):
+def query_wfsc_images_latest(detector='NRCA1', productlevel='2b'):
     """MAST query to get filenames of the most recent WFSC images
 
     Returns table of MAST query results
+
+    As of cycle 4, this is looking for NRCA1_FP6 aperture using detector NRCA1, and undithered exposures (level 2b)
     """
     # Query MAST for the most recent level-3 WFSC combined products
     now = astropy.time.Time.now()


### PR DESCRIPTION
Minor fix PR. There's a little-used function in mast_wss, `query_wfsc_images_latest`, that returns the filenames of the latest WFS images taken. The WFS program changes for cycle 4 led to this not working because it was searching for level 3 wfscmb images, but the now-undithered observations don't make level 3 outputs. This doesn't get much use any more since the TAS is more mature but the function still exists so it should work, especially since there's a unit test and it was making that test function fail. I updated the query criteria to search for level 2b outputs.   

This explanation text is about a hundred times longer than the actual content of the PR ;-)