### PR TITLE
Update ci with prerelease

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   retrieve_cache:
-    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@1b4adc279d0e3c76e01d975fb2a46a10258b5d53 # setup retrieve_cache with development or latest_release
+    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@00753c8ce7ca592757825061d3ee2fa36ec329df # setup retrieve_cache with development or latest_release
     with:
       dataset_type: development   # or latest_release
   tests:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,7 +4,9 @@ on: [push, pull_request]
 
 jobs:
   retrieve_cache:
-    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@68bfa1fe978b05c892672e715f0666ecf999d32f  # v2.1.1
+    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@68bfa1fe978b05c892672e715f0666ecf999d32f  # v2.1.1 - prerelease implementation
+    with:
+      dataset_type: prerel   # or "full"
   tests:
     needs: [ retrieve_cache ]
     name: ${{ matrix.name }}
@@ -13,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-
           - name: Coverage test in Python 3
             os: ubuntu-latest
             python: '3.11'

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   retrieve_cache:
-    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@main
+    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@1b4adc279d0e3c76e01d975fb2a46a10258b5d53 # setup retrieve_cache with development or latest_release
     with:
       dataset_type: development   # or latest_release
   tests:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,9 +4,9 @@ on: [push, pull_request]
 
 jobs:
   retrieve_cache:
-    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@68bfa1fe978b05c892672e715f0666ecf999d32f  # v2.1.1 - prerelease implementation
+    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@main
     with:
-      dataset_type: prerel   # or "full"
+      dataset_type: development   # or latest_release
   tests:
     needs: [ retrieve_cache ]
     name: ${{ matrix.name }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,9 +4,7 @@ on: [push, pull_request]
 
 jobs:
   retrieve_cache:
-    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@098e3d3515d906bbfa12680d2282ec8d6726527b  # v1.5.2
-    with:
-      minimal: true
+    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@68bfa1fe978b05c892672e715f0666ecf999d32f  # v2.1.1
   tests:
     needs: [ retrieve_cache ]
     name: ${{ matrix.name }}

--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -28,10 +28,10 @@ on:
   workflow_call:
     inputs:
       dataset_type:
-        description: Which dataset to download and cache (prerel or full)
+        description: "Choose dataset type ('development' or 'latest_release')"
         type: string
-        required: true
-        default: prerel
+        required: false
+        default: development
     outputs:
       version:
         value: ${{ jobs.download.outputs.version }}
@@ -43,10 +43,10 @@ on:
   workflow_dispatch:
     inputs:
       dataset_type:
-        description: Which dataset to download and cache (prerel or full)
+        description: Which dataset type ('development' or 'latest_release')"
         type: string
-        required: true
-        default: prerel
+        required: false
+        default: development
 
   schedule:
     - cron: "0 0 * * 0"   # weekly
@@ -56,8 +56,8 @@ on:
       - develop
 
 env:
-  PREREL_URL: https://stsci.box.com/shared/static/50i1h17hij7r3pki8zmaxsh8o7pyqj79.gz
-  FULL_URL: https://stsci.box.com/shared/static/kqfolg2bfzqc4mjkgmujo06d3iaymahv.gz
+  PRERELEASE_URL: https://stsci.box.com/shared/static/50i1h17hij7r3pki8zmaxsh8o7pyqj79.gz
+  LATEST_RELEASE_URL: https://stsci.box.com/shared/static/kqfolg2bfzqc4mjkgmujo06d3iaymahv.gz
 
 jobs:
   download:
@@ -67,10 +67,10 @@ jobs:
       - name: Select dataset URL
         id: dataset_url
         run: |
-          if [ "${{ inputs.dataset_type }}" = "prerel" ]; then
-            echo "url=${{ env.PREREL_URL }}" >> $GITHUB_OUTPUT
-          elif [ "${{ inputs.dataset_type }}" = "full" ]; then
-            echo "url=${{ env.FULL_URL }}" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.dataset_type }}" = "development" ]; then
+            echo "url=${{ env.PRERELEASE_URL }}" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.dataset_type }}" = "latest_release" ]; then
+            echo "url=${{ env.LATEST_RELEASE_URL }}" >> $GITHUB_OUTPUT
           else
             echo "Unsupported dataset_type: ${{ inputs.dataset_type }}" >&2
             exit 1

--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -1,7 +1,7 @@
 # Downloads STPSF dataset and caches it to GitHub cache,
 # making a new cache for a new data version
 # the cache key is in the form `stpsf-data-mini-1.3.0`,
-# `stpsf-data-full-1.2.6`, etc.
+# `stpsf-data-full-1.3.0`, `stpsf-data-prerel-1.3.1` etc.
 #
 # To provide your own test workflow with the STPSF dataset,
 # you should use this workflow to set up a cache in your repository,
@@ -22,21 +22,10 @@
 #     with:
 #       minimal: true
 
-name: download and cache data
+name: download and cache prerelease data
 
 on:
   workflow_call:
-    inputs:
-      url:
-        description: URL to gzip file
-        type: string
-        required: false
-        default: https://stsci.box.com/shared/static/3hzmbarac5yxjt6x7gn17vz02k7c8z1d.gz
-      minimal:
-        description: dataset is minimal (as opposed to full)
-        type: boolean
-        required: false
-        default: true
     outputs:
       version:
         value: ${{ jobs.download.outputs.version }}
@@ -44,47 +33,46 @@ on:
         value: ${{ jobs.download.outputs.cache_path }}
       cache_key:
         value: ${{ jobs.download.outputs.cache_key }}
-  workflow_dispatch:
-    inputs:
-      url:
-        description: URL to gzip file
-        type: string
-        required: false
-        default: https://stsci.box.com/shared/static/3hzmbarac5yxjt6x7gn17vz02k7c8z1d.gz
-      minimal:
-        description: dataset is minimal (as opposed to full)
-        type: boolean
-        required: false
-        default: true
+
+  workflow_dispatch:   # manual trigger
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * 0"   # weekly
   release:
   push:
     branches:
       - develop
 
 env:
-  FULL_DATA_URL: https://stsci.box.com/shared/static/kqfolg2bfzqc4mjkgmujo06d3iaymahv.gz
-  MINIMAL_DATA_URL: https://stsci.box.com/shared/static/3hzmbarac5yxjt6x7gn17vz02k7c8z1d.gz
+  PRE_RELEASE_URL: https://stsci.box.com/shared/static/50i1h17hij7r3pki8zmaxsh8o7pyqj79.gz
 
 jobs:
   download:
-    name: download and cache STPSF data
+    name: download and cache latest development (prerelease) STPSF data
     runs-on: ubuntu-latest
     steps:
-      - run: wget ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && inputs.url || env.MINIMAL_DATA_URL }} -O ${{ runner.temp }}/stpsf-data.tar.gz
-      - run: mkdir ${{ runner.temp }}/data/
-      - run: tar -xzvf ${{ runner.temp }}/stpsf-data.tar.gz -C ${{ runner.temp }}/data/
+      - name: Download prerelease dataset
+        run: wget ${{ env.PRE_RELEASE_URL }} -O ${{ runner.temp }}/stpsf-data.tar.gz
+
+      - name: Extract dataset
+        run: |
+          mkdir -p ${{ runner.temp }}/data/
+          tar -xzvf ${{ runner.temp }}/stpsf-data.tar.gz -C ${{ runner.temp }}/data/
+
       - id: cache_path
-        run: echo cache_path=${{ runner.temp }}/data/ >> $GITHUB_OUTPUT
+        run: echo "cache_path=${{ runner.temp }}/data/" >> $GITHUB_OUTPUT
+
       - id: version
         run: echo "version=$(cat ${{ steps.cache_path.outputs.cache_path }}/stpsf-data/version.txt)" >> $GITHUB_OUTPUT
+
       - id: cache_key
-        run: echo "cache_key=stpsf-data-mini-${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4  # v4.0.2
+        run: echo "cache_key=stpsf-data-prerel-${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
+
+      - name: Save cache
+        uses: actions/cache@v4
         with:
           path: ${{ runner.temp }}/data/
           key: ${{ steps.cache_key.outputs.cache_key }}
+
     outputs:
       version: ${{ steps.version.outputs.version }}
       cache_path: ${{ steps.cache_path.outputs.cache_path }}

--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -1,6 +1,6 @@
 # Downloads STPSF dataset and caches it to GitHub cache,
 # making a new cache for a new data version
-# the cache key is in the form `stpsf-data-mini-1.3.0`,
+# the cache key is in the form
 # `stpsf-data-full-1.3.0`, `stpsf-data-prerel-1.3.1` etc.
 #
 # To provide your own test workflow with the STPSF dataset,
@@ -22,10 +22,16 @@
 #     with:
 #       minimal: true
 
-name: download and cache prerelease data
+name: download and cache STPSF data
 
 on:
   workflow_call:
+    inputs:
+      dataset_type:
+        description: Which dataset to download and cache (prerel or full)
+        type: string
+        required: true
+        default: prerel
     outputs:
       version:
         value: ${{ jobs.download.outputs.version }}
@@ -34,7 +40,14 @@ on:
       cache_key:
         value: ${{ jobs.download.outputs.cache_key }}
 
-  workflow_dispatch:   # manual trigger
+  workflow_dispatch:
+    inputs:
+      dataset_type:
+        description: Which dataset to download and cache (prerel or full)
+        type: string
+        required: true
+        default: prerel
+
   schedule:
     - cron: "0 0 * * 0"   # weekly
   release:
@@ -43,15 +56,28 @@ on:
       - develop
 
 env:
-  PRE_RELEASE_URL: https://stsci.box.com/shared/static/50i1h17hij7r3pki8zmaxsh8o7pyqj79.gz
+  PREREL_URL: https://stsci.box.com/shared/static/50i1h17hij7r3pki8zmaxsh8o7pyqj79.gz
+  FULL_URL: https://stsci.box.com/shared/static/kqfolg2bfzqc4mjkgmujo06d3iaymahv.gz
 
 jobs:
   download:
-    name: download and cache latest development (prerelease) STPSF data
+    name: download and cache STPSF ${{ inputs.dataset_type }} data
     runs-on: ubuntu-latest
     steps:
-      - name: Download prerelease dataset
-        run: wget ${{ env.PRE_RELEASE_URL }} -O ${{ runner.temp }}/stpsf-data.tar.gz
+      - name: Select dataset URL
+        id: dataset_url
+        run: |
+          if [ "${{ inputs.dataset_type }}" = "prerel" ]; then
+            echo "url=${{ env.PREREL_URL }}" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.dataset_type }}" = "full" ]; then
+            echo "url=${{ env.FULL_URL }}" >> $GITHUB_OUTPUT
+          else
+            echo "Unsupported dataset_type: ${{ inputs.dataset_type }}" >&2
+            exit 1
+          fi
+
+      - name: Download dataset
+        run: wget ${{ steps.dataset_url.outputs.url }} -O ${{ runner.temp }}/stpsf-data.tar.gz
 
       - name: Extract dataset
         run: |
@@ -65,7 +91,7 @@ jobs:
         run: echo "version=$(cat ${{ steps.cache_path.outputs.cache_path }}/stpsf-data/version.txt)" >> $GITHUB_OUTPUT
 
       - id: cache_key
-        run: echo "cache_key=stpsf-data-prerel-${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
+        run: echo "cache_key=stpsf-data-${{ inputs.dataset_type }}-${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
 
       - name: Save cache
         uses: actions/cache@v4
@@ -77,4 +103,3 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       cache_path: ${{ steps.cache_path.outputs.cache_path }}
       cache_key: ${{ steps.cache_key.outputs.cache_key }}
-

--- a/.github/workflows/retrieve_cache.yml
+++ b/.github/workflows/retrieve_cache.yml
@@ -48,10 +48,6 @@ on:
 jobs:
   retrieve:
     runs-on: ubuntu-latest
-    outputs:
-      cache_path: ${{ steps.set-outputs.outputs.cache_path }}
-      cache_key: ${{ steps.set-outputs.outputs.cache_key }}
-      version: ${{ steps.set-outputs.outputs.version }}
     steps:
       - name: Determine cache key
         id: cache-key

--- a/.github/workflows/retrieve_cache.yml
+++ b/.github/workflows/retrieve_cache.yml
@@ -77,3 +77,7 @@ jobs:
           echo "version=${{ steps.cache-key.outputs.version }}" >> $GITHUB_OUTPUT
           echo "cache_path=${{ steps.cache-key.outputs.cache_path }}" >> $GITHUB_OUTPUT
 
+    outputs:
+      cache_path: ${{ steps.set-outputs.outputs.cache_path }}
+      cache_key: ${{ steps.set-outputs.outputs.cache_key }}
+      version: ${{ steps.set-outputs.outputs.version }}

--- a/.github/workflows/retrieve_cache.yml
+++ b/.github/workflows/retrieve_cache.yml
@@ -27,61 +27,53 @@
 #          key: ${{ needs.stpsf_data_cache_key.outputs.cache_key }}
 #       ...
 
-name: retrieve latest STPSF data cache key
+name: retrieve cache
 
 on:
   workflow_call:
     inputs:
       dataset_type:
-        description: Which dataset to retrieve (prerel or full)
+        description: "Choose dataset type ('development' or 'latest_release')"
         type: string
-        required: true
-        default: prerel
+        required: false
+        default: development
     outputs:
-      version:
-        value: ${{ jobs.retrieve.outputs.version }}
       cache_path:
         value: ${{ jobs.retrieve.outputs.cache_path }}
       cache_key:
         value: ${{ jobs.retrieve.outputs.cache_key }}
-
-permissions:
-  actions: read
-  contents: read
+      version:
+        value: ${{ jobs.retrieve.outputs.version }}
 
 jobs:
   retrieve:
-    name: retrieve latest STPSF ${{ inputs.dataset_type }} data cache key
     runs-on: ubuntu-latest
-    steps:
-      - name: Install gh actions-cache extension
-        run: gh extension install actions/gh-actions-cache || true
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Find latest cache key
-        id: latest_cache_key
-        run: |
-          CACHE_KEY=$(gh actions-cache list -R ${{ github.repository }} \
-            --key stpsf-data-${{ inputs.dataset_type }}- \
-            --sort created-at | cut -f 1 | head -n 1)
-          if [ -z "$CACHE_KEY" ]; then
-            echo "No cache found for dataset_type=${{ inputs.dataset_type }}" >&2
-            exit 1
-          fi
-          echo "cache_key=$CACHE_KEY" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Derive version from key
-        id: version
-        run: |
-          KEY="${{ steps.latest_cache_key.outputs.cache_key }}"
-          VERSION="${KEY#stpsf-data-${{ inputs.dataset_type }}-}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      cache_path: ${{ runner.temp }}/data/
-      cache_key: ${{ steps.latest_cache_key.outputs.cache_key }}
+      cache_path: ${{ steps.set-outputs.outputs.cache_path }}
+      cache_key: ${{ steps.set-outputs.outputs.cache_key }}
+      version: ${{ steps.set-outputs.outputs.version }}
+    steps:
+      - name: Determine cache key
+        id: cache-key
+        run: |
+          PREFIX="stpsf-data-${{ inputs.dataset_type }}-"
+
+          # Find the most recent cache key matching dataset type
+          CACHE_KEY=$(gh actions-cache list -R ${{ github.repository }} --key "$PREFIX" --sort created-at | cut -f1 | head -n1)
+
+          echo "cache_key=$CACHE_KEY" >> $GITHUB_OUTPUT
+
+          # Extract version (suffix after prefix, if present)
+          VERSION=${CACHE_KEY#"$PREFIX"}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Path where cache would be restored
+          echo "cache_path=/tmp/stpsf-cache/$CACHE_KEY" >> $GITHUB_OUTPUT
+
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          echo "cache_key=${{ steps.cache-key.outputs.cache_key }}" >> $GITHUB_OUTPUT
+          echo "version=${{ steps.cache-key.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "cache_path=${{ steps.cache-key.outputs.cache_path }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/retrieve_cache.yml
+++ b/.github/workflows/retrieve_cache.yml
@@ -27,39 +27,58 @@
 #          key: ${{ needs.stpsf_data_cache_key.outputs.cache_key }}
 #       ...
 
-name: retrieve latest prerelease data cache key
+name: retrieve latest STPSF data cache key
 
 on:
   workflow_call:
+    inputs:
+      dataset_type:
+        description: Which dataset to retrieve (prerel or full)
+        type: string
+        required: true
+        default: prerel
     outputs:
       version:
-        value: ${{ jobs.retrieve_latest_cache_key.outputs.version }}
+        value: ${{ jobs.retrieve.outputs.version }}
       cache_path:
-        value: ${{ jobs.retrieve_latest_cache_key.outputs.cache_path }}
+        value: ${{ jobs.retrieve.outputs.cache_path }}
       cache_key:
-        value: ${{ jobs.retrieve_latest_cache_key.outputs.cache_key }}
+        value: ${{ jobs.retrieve.outputs.cache_key }}
+
+permissions:
+  actions: read
+  contents: read
 
 jobs:
-  retrieve_latest_cache_key:
-    name: retrieve latest prerelease STPSF data cache key
+  retrieve:
+    name: retrieve latest STPSF ${{ inputs.dataset_type }} data cache key
     runs-on: ubuntu-latest
     steps:
-      - name: retrieve latest prerelease data cache key
-        id: latest_cache_key
-        run: |
-          gh extension install actions/gh-actions-cache
-          CACHE_KEY=$(gh actions-cache list -R ${{ github.repository }} \
-            --key stpsf-data-prerel- \
-            --sort created-at | cut -f 1 | head -n 1)
-          if [ -z "$CACHE_KEY" ]; then exit 1; fi
-          echo cache_key=$CACHE_KEY >> $GITHUB_OUTPUT
+      - name: Install gh actions-cache extension
+        run: gh extension install actions/gh-actions-cache || true
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - run: echo "Latest cache key: ${{ steps.latest_cache_key.outputs.cache_key }}"
+      - name: Find latest cache key
+        id: latest_cache_key
+        run: |
+          CACHE_KEY=$(gh actions-cache list -R ${{ github.repository }} \
+            --key stpsf-data-${{ inputs.dataset_type }}- \
+            --sort created-at | cut -f 1 | head -n 1)
+          if [ -z "$CACHE_KEY" ]; then
+            echo "No cache found for dataset_type=${{ inputs.dataset_type }}" >&2
+            exit 1
+          fi
+          echo "cache_key=$CACHE_KEY" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
-      - id: version
-        run: echo "version=$(echo ${{ steps.latest_cache_key.outputs.cache_key }} | awk -F '-' '{print $4}')" >> $GITHUB_OUTPUT
+      - name: Derive version from key
+        id: version
+        run: |
+          KEY="${{ steps.latest_cache_key.outputs.cache_key }}"
+          VERSION="${KEY#stpsf-data-${{ inputs.dataset_type }}-}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/retrieve_cache.yml
+++ b/.github/workflows/retrieve_cache.yml
@@ -1,6 +1,6 @@
 # retrieves the latest cache key for STPSF data;
 # the cache key is in the form `stpsf-data-mini-1.3.0`,
-# `stpsf-data-full-1.2.6`, etc.
+# `stpsf-data-full-1.3.0`, `stpsf-data-prerel-1.3.1` etc.
 #
 # to retrieve the STPSF data cache in your test workflow,
 # first create a cache of the dataset in your repository
@@ -27,16 +27,10 @@
 #          key: ${{ needs.stpsf_data_cache_key.outputs.cache_key }}
 #       ...
 
-name: retrieve latest data cache key
+name: retrieve latest prerelease data cache key
 
 on:
   workflow_call:
-    inputs:
-      minimal:
-        description: minimal dataset
-        type: boolean
-        required: false
-        default: true
     outputs:
       version:
         value: ${{ jobs.retrieve_latest_cache_key.outputs.version }}
@@ -47,23 +41,28 @@ on:
 
 jobs:
   retrieve_latest_cache_key:
-    name: retrieve latest STPSF data cache key
+    name: retrieve latest prerelease STPSF data cache key
     runs-on: ubuntu-latest
     steps:
-      - name: retrieve latest data cache key
+      - name: retrieve latest prerelease data cache key
         id: latest_cache_key
         run: |
-          # use actions/gh-actions-cache to allow filtering by key
           gh extension install actions/gh-actions-cache
-          CACHE_KEY=$(gh actions-cache list -R ${{ github.repository }} --key stpsf-data-${{ inputs.minimal && 'mini' || 'full' }}- --sort created-at | cut -f 1 | head -n 1)
-          if [ "$CACHE_KEY" == '' ]; then exit 1; fi
+          CACHE_KEY=$(gh actions-cache list -R ${{ github.repository }} \
+            --key stpsf-data-prerel- \
+            --sort created-at | cut -f 1 | head -n 1)
+          if [ -z "$CACHE_KEY" ]; then exit 1; fi
           echo cache_key=$CACHE_KEY >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
-      - run: echo ${{ steps.latest_cache_key.outputs.cache_key }}
+
+      - run: echo "Latest cache key: ${{ steps.latest_cache_key.outputs.cache_key }}"
+
       - id: version
         run: echo "version=$(echo ${{ steps.latest_cache_key.outputs.cache_key }} | awk -F '-' '{print $4}')" >> $GITHUB_OUTPUT
+
     outputs:
       version: ${{ steps.version.outputs.version }}
       cache_path: ${{ runner.temp }}/data/
       cache_key: ${{ steps.latest_cache_key.outputs.cache_key }}
+


### PR DESCRIPTION
Update the CI to use the new PRE-RELEASE data on box.
When data changes we want to be able to still verify using our CI without altering the data other repositories use.