### PR TITLE
Implement model for IEC-driven WFE astigmatism

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ docs = [
     "sphinx-issues",
     "tomli; python_version <\"3.11\"",
 ]
+jwst = [
+    "jwst",
+]
 
 [project.urls]
 Homepage = "http://stpsf.readthedocs.io/"

--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -409,3 +409,22 @@ INSTRUMENT_IFU_BROADENING_PARAMETERS = {
     'NIRSPEC': {'sigma': 0.05},
     'MIRI': {'sigma': 0.05},
 }
+
+# Information about the effects on WFE of the IEC thermal variations
+#
+# Table of value for IEC telemetry to WFE model. Coefficients from model fit by Randal Telfer
+# Method as in Telfer et al. 2024 Proc. SPIE
+# Model Amp and Lag values from an updated fit to more data, delivered by email from Telfer to Perrin & Melendez on 2024 Nov 25
+# T_mean values from time average semi-arbitrarily over all of 2024 January; this is mostly just a convenience cache
+# to avoid having to recompute T_mean each time, and to ensure a mean over a suitably long time period
+iec_mnemonics = (
+    # Mnemonic       Model_amp   Lag     T_mean
+    #                [RMS nm/K]  [min]   [K]
+    ('ST_ZTC1FGSIA', 1.425,      0.027,  280.706933),
+    ('ST_ZTC2FGSIA', 3.327,     -0.075,  280.420823),
+    ('ST_ZTC1MIRIA', 0.593,      1.148,  280.642024),
+    ('ST_ZTC2NRCDA', 0.472,     -0.037,  280.433027),
+    ('ST_ZTC3NRCDA', 2.530,     -0.084,  280.821185),
+    # uncertainties in amplitude are ± 0.039 - 0.106 nm/K
+    # uncertainties in lag are ± 0.075 - 0.109 min
+)

--- a/stpsf/mast_wss.py
+++ b/stpsf/mast_wss.py
@@ -896,6 +896,7 @@ def retrieve_iec_heater_telemetry(tstart, tend, plot=False):
 
 
     if plot:
+        import matplotlib.pyplot as plt
         fig, ax = plt.subplots(figsize=(16,4))
 
         for mnemonic, *other_vals in stpsf.constants.iec_mnemonics:

--- a/stpsf/mast_wss.py
+++ b/stpsf/mast_wss.py
@@ -862,3 +862,50 @@ def query_program_visit_times(program, verbose=False):
 
     # visit_times = np.asarray(visit_times)
     return astropy.table.Table([vids, starts, ends], names=('visit_id', 'start_mjd', 'end_mjd'))
+
+# Functions for retrieving telemetry about observatory wavefront variations, in particular the IEC thermal oscillations
+
+@functools.lru_cache
+def retrieve_iec_heater_telemetry(tstart, tend, plot=False):
+    """Retrieve JWST Instrument Electronics Compartment (IEC) heater telemetry, for use in de-trending WFSC
+
+    Parameters
+    ----------
+    tstart, tstop : strings
+        Datetimes for start and stop of time range
+
+    plot : bool
+
+    Make a plot, for test or debugging purposes.
+
+
+    """
+    import stpsf.constants
+
+    from jwst.lib.engdb_tools import ENGDB_Service
+    engdb_service = ENGDB_Service()  # By default, will use the public MAST service.
+
+    iecvals = {}
+
+    for mnemonic, amp, lag, t_mean in stpsf.constants.iec_mnemonics:
+        times, values = engdb_service.get_values(mnemonic, tstart, tend, include_obstime=True, zip_results=False)
+        if len(times)== 0:
+            raise RuntimeError(f"Found no results for {mnemonic} between {tstart} - {tend}")
+        times = astropy.time.Time([v.value for v in times])   # Convert from list of Times to one Time with an ndarray of values.
+        iecvals[mnemonic] = times, np.asarray(values)
+
+
+    if plot:
+        fig, ax = plt.subplots(figsize=(16,4))
+
+        for mnemonic, *other_vals in stpsf.constants.iec_mnemonics:
+            times, values = iecvals[mnemonic]
+            ax.plot(times.plot_date, values, label=mnemonic)
+        ax.legend()
+
+        ax.xaxis.axis_date()
+
+        ax.set_ylabel("Temp [K]")
+        ax.set_xlabel("Time [UTC]")
+        fig.tight_layout()
+    return iecvals

--- a/stpsf/opds.py
+++ b/stpsf/opds.py
@@ -1284,7 +1284,24 @@ class OTE_Linear_Model_WSS(OPD):
             print('  \t %10s %10s %10s %10s %10s     n/a' % tuple(self._sm_control_modes))
             segment = 18
             thatsegment = self.segment_state[18]
+            print('%2s\t %10.4f %10.4f %10.4f %10.4f %10.4f %10.4f' % tuple(['SM'] + thatsegment.tolist()))
+        print(f"\nPlus IEC-induced WFE with ampliude {self._iec_wfe_amplitude:.2f} nm rms")
+
+        print("\n--------------------\nPM Total Segment State (including pose + IEC drifts + thermal/frill drifts:")
+        total_segment_state = self.segment_state + self._get_frill_drift_poses() + self._get_iec_drift_poses()
+        print('Segment poses in Control coordinates: (microns for decenter & piston, microradians for tilts and clocking):')
+        print('  \t %10s %10s %10s %10s %10s %10s' % tuple(self._control_modes))
+        for i, segment in enumerate(self.segnames[0:18]):
+            thatsegment = total_segment_state[i]
+
             print('%2s\t %10.4f %10.4f %10.4f %10.4f %10.4f %10.4f' % tuple([segment] + thatsegment.tolist()))
+        if len(self.segnames) == 19:  # SM is present
+            print('Secondary Mirror Pose in Control coordinates: ')
+            print('  \t %10s %10s %10s %10s %10s     n/a' % tuple(self._sm_control_modes))
+            segment = 18
+            thatsegment = self.segment_state[18]
+            print('%2s\t %10.4f %10.4f %10.4f %10.4f %10.4f %10.4f' % tuple(['SM'] + thatsegment.tolist()))
+
 
     # ---- segment manipulation via linear model
 
@@ -2501,7 +2518,7 @@ class OTE_Linear_Model_WSS(OPD):
         if display:
             self.display()
 
-    def _get_dynamic_opd(self, delta_time=14 * u.day, case='EOL'):
+    def _get_dynamic_opd(self, iec_mode=True, pitch_mode=True, delta_time=0 * u.day, case='FLIGHT'):
         """Return ONLY the dynamic portion of the OPD, including thermal slew + frill + IEC
         Normally these are all folded up as part of the update_opd method, but it can be
         useful in certain circumstances to extract just this part, e.g. for plotting or analysis
@@ -2530,7 +2547,11 @@ class OTE_Linear_Model_WSS(OPD):
         # sm_pose_coeffs.shape = (5, 1)  # to allow broadcasting below
         sm_pose_coeffs = np.zeros((5, 1))
 
-        drift_segment_state = self._get_frill_drift_poses() + self._get_iec_drift_poses()
+        drift_segment_state = np.zeros((19, 6), float)
+        if iec_mode:
+            drift_segment_state += self._get_iec_drift_poses()
+        if pitch_mode:
+            drift_segment_state += self._get_frill_drift_poses()
 
         for iseg, segname in enumerate(self.segnames[0:18]):
             pose_coeffs = drift_segment_state[iseg].copy()
@@ -2650,12 +2671,10 @@ class OTE_Linear_Model_WSS(OPD):
 
         return ote_seg_motions_frill * self._frill_wfe_amplitude
 
-    def apply_iec_drift(self, amplitude=None, random=False, case='BOL', delay_update=False):
-        """Apply model of segment PTT motions for the drift seen at OTIS induced by the IEC
-        (Instrument Electronics Compartment) heater resistors. This effect was in part due to
-        non-flight-like ground support equipment mountings, and is not expected in flight at
-        the same levels it was seen at JSC. We model it anyway, at an amplitude consistent with
-        upper limits for flight.
+    def apply_iec_drift(self, amplitude, delay_update=False):
+        """Apply model of segment PTT motions for the drift induced by the IEC
+        (Instrument Electronics Compartment) heater resistors. The spatial pattern
+        used here is based on the analyses presented in Telfer et al. 2024 Proc. SPIE.
 
         This is additive with other WFE terms.
 
@@ -2663,30 +2682,13 @@ class OTE_Linear_Model_WSS(OPD):
         ----------
         amplitude : float
             Amplitude of drift in nm rms to apply
-        random : bool
-            if True, choose a random amplitude from within the expected range
-            for either the BOL or EOL cases. The assumed model is a sinusoidal drift
-            between 0 and 3.5 nm, i.e. a random variate from the arcsine distribution
-            times 3.5.
-        case : string
-            either "BOL" for current best estimate at beginning of life, or
-            "EOL" for more conservative prediction at end of life. Only relevant
-            if random=True. (Note, for IEC drift the amplitude is the same regardless.)
         delay_update : bool
             hold off on computing the WFE change? This is useful for computational efficiency if you're
             making many changes at once.
         """
 
-        # These segment piston/tip/tilt misalignments are normalized to give 1 nm rms.
-        if random:
-            max_amp = 3.5  # regardless of EOL or BOL
-
-            amplitude = scipy.stats.arcsine().rvs() * max_amp
-            _log.info(f'Applying random IEC-induced drift with amplitude {amplitude} nm rms (out of max {max_amp} nm rms).')
-        elif amplitude is None:
-            raise ValueError('if random=False, you must provide a value for the amplitude.')
-        else:
-            _log.info(f'Applying IEC-induced drift with amplitude {amplitude} nm rms.')
+        # The drift segment piston/tip/tilt misalignments are normalized to give 1 nm rms.
+        _log.info(f'Applying IEC-induced drift with amplitude {amplitude} nm rms.')
         self._iec_wfe_amplitude = amplitude
 
         if not delay_update:
@@ -2694,40 +2696,39 @@ class OTE_Linear_Model_WSS(OPD):
 
     def _get_iec_drift_poses(self):
         # These segment piston/tip/tilt motions approximate the OTE observed
-        # oscillation seen at JSC OTIS cryo vac test, due to IEC heater thermal loading
-        # through GSE paths.
+        # oscillation seen in flight due to IEC heater thermal loading.
 
-        # Developed in the PFR190 study by Perrin & Telfer as
-        # oscillation_opd_case1_var2_ptt.fits.gz; decomposed into segment PTT by Perrin
-        # in "Make PSF Sim Library for JWST cycle 1 props - Development.ipynb"
-
+        # Measured in flight by R. Telfer, delivered to Perrin as 'IEC_av_net_all.fits'
+        # Decomposed into segment PTT by Perrin in
+        # "Develop IEC WFE Flight Model for STPSF.ipynb"
         ote_seg_motions_iec = (
-            np.array(
-                [
-                    [0.5211, 0.2925, -0.3567, 0.0, 0.0, 0.0],
-                    [-0.0652, 0.2788, 0.1896, 0.0, 0.0, 0.0],
-                    [0.2491, -0.2203, 0.1522, 0.0, 0.0, 0.0],
-                    [0.4078, 0.1386, 0.0301, 0.0, 0.0, 0.0],
-                    [-0.0663, -0.0702, 0.2119, 0.0, 0.0, 0.0],
-                    [0.3488, -0.3986, -0.2216, 0.0, 0.0, 0.0],
-                    [0.4363, -0.4034, -0.5762, 0.0, 0.0, 0.0],
-                    [-0.584, -0.4198, -0.0271, 0.0, 0.0, 0.0],
-                    [1.1319, -0.195, 0.8383, 0.0, 0.0, 0.0],
-                    [0.3116, -0.4376, 0.4631, 0.0, 0.0, 0.0],
-                    [-0.0052, 0.6276, -0.1083, 0.0, 0.0, 0.0],
-                    [0.1727, 0.6529, -0.5457, 0.0, 0.0, 0.0],
-                    [-0.3807, -0.4189, -0.602, 0.0, 0.0, 0.0],
-                    [-0.4924, -0.1094, 0.0996, 0.0, 0.0, 0.0],
-                    [1.0861, -0.1953, 0.8371, 0.0, 0.0, 0.0],
-                    [0.4202, -0.6961, 0.3543, 0.0, 0.0, 0.0],
-                    [0.7644, 0.6466, -0.0861, 0.0, 0.0, 0.0],
-                    [0.1887, 0.0825, -0.7851, 0.0, 0.0, 0.0],
-                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-                ]
-            )
-            / 1000
+                       # Fit coordinates in WSS control basis, scaled to have 1 nm RMS, in units of nm
+                       # Xtilt          YTilt    Piston       clocking, rad_trans, RoC
+            np.array([[-0.58259548, -0.33075706, -0.05476588, 0, 0, 0],
+                   [-0.12024492, -0.26902193, -0.44873196, 0, 0, 0],
+                   [-0.41292732,  0.43535294, -0.24294152, 0, 0, 0],
+                   [-0.71582482, -0.32755135, -0.13868752, 0, 0, 0],
+                   [-0.02381347,  0.20343897, -0.32245266, 0, 0, 0],
+                   [-0.56024322,  0.30239843,  0.05709397, 0, 0, 0],
+                   [ 0.22943398,  0.60499065,  0.44779136, 0, 0, 0],
+                   [ 0.20461637,  0.09357965, -0.16961389, 0, 0, 0],
+                   [-0.04657445,  0.10656212, -0.37515802, 0, 0, 0],
+                   [-0.2914627 , -0.03065583, -0.30805125, 0, 0, 0],
+                   [ 0.23847799, -0.55356551,  0.28530475, 0, 0, 0],
+                   [-0.36600475, -0.86378628,  0.91148742, 0, 0, 0],
+                   [ 0.46851786,  1.18566825,  0.68334293, 0, 0, 0],
+                   [ 0.17738028,  0.2308024 , -0.40605515, 0, 0, 0],
+                   [-0.43693984, -0.04438047, -0.66063669, 0, 0, 0],
+                   [-0.42718532,  0.28414531, -0.21359245, 0, 0, 0],
+                   [-0.01165143, -0.48412486,  0.41933479, 0, 0, 0],
+                   [ 0.01821291, -0.39035983,  0.68854777, 0, 0, 0],
+                      [ 0.0, 0.0, 0.0, 0, 0, 0]])  # SM is unaffected by IEC
+            / 1000  # convert from nm to microns
         )
         return ote_seg_motions_iec * self._iec_wfe_amplitude
+
+#    def display_component(self, ):
+#        pass
 
     def header_keywords(self):
         """Return info we would like to save in FITS header of output PSFs"""
@@ -3021,6 +3022,91 @@ def convert_quantity(input_quantity, from_units=None, to_units=u.day):
         output_quantity = input_quantity.to(to_units)
 
     return output_quantity
+
+def estimate_iec_induced_wfe_at_time(times, plot=False):
+    """ Estimate the IEC-induced WFE amplitude at given time(s) based on observatory thermal telemetry
+    Implements the model described in Telfer et al. Proc SPIE 2024
+
+    Parameters
+    ----------
+    times : str or astropy Time, or iterable list/ndarray of those
+        Time(s) to compute the WFE for, in a format understandable by astropy.time.Time
+        Must be a past time for which observatory telemetry is available in MAST. In
+        principle this should be true for any time from launch until a few hours before
+        the current time, for any time during which JWST is operational.
+    plot : bool
+        Make a plot? Mostly for test and debugging.
+    """
+
+    # Ensure we are working with astropy Times
+    times_array = astropy.time.Time(times)
+
+    # Retrieve the IEC heater telemetry, over a slightly padded time range to accomodate the measured delays
+    time_padding = 2* np.max(np.abs([lag for mnemonic, amp, lag, t_mean in constants.iec_mnemonics])) * astropy.units.minute
+    tstart_padded = times_array.min() - time_padding
+    tend_padded = times_array.max() + time_padding
+
+    iecvals = stpsf.mast_wss.retrieve_iec_heater_telemetry(tstart_padded, tend_padded, plot=False)
+
+    # To get the WFE at a given time, we need temporally shifted (via interpolation) version of the heater telemetry.
+    interpolators = {}
+    for mnemonic, amp, lag, t_mean in constants.iec_mnemonics:
+        telem_times, telem_values = iecvals[mnemonic]
+
+        # For convenience we do all the interpolations using MJD for the time axis
+        # Set up an interpolator for the measured telemetry
+        interpolators[mnemonic] = scipy.interpolate.interp1d(telem_times.mjd, telem_values, kind='cubic', fill_value='extrapolate')
+
+    # Define inline a summed interpolator which we will use below. We do it this way to help enable the plot functionality
+    def interpolate_iec_wfe_coeff(times_array):
+        iec_wfe_coeff = np.zeros_like(times_array, float)
+        shifted_iecvals = {}
+        for mnemonic, amp, lag, t_mean in constants.iec_mnemonics:
+            # Evaluate that for the requested times, taking into account the calibrated lag.
+            shifted_iecvals[mnemonic] = interpolators[mnemonic]((times_array - lag*astropy.units.minute).mjd)
+
+            iec_wfe_coeff += amp * (shifted_iecvals[mnemonic] - t_mean)
+        return iec_wfe_coeff
+
+    iec_wfe_coeff = interpolate_iec_wfe_coeff(times_array)
+
+    if plot:
+        fig, axes = plt.subplots(figsize=(16,9), nrows=2)
+        plot_times = astropy.time.Time(np.linspace(tstart_padded.mjd, tend_padded.mjd, 1000), format='mjd')
+
+        # This code is intentionally a bit repetitive of the above, to plot the intermediate quantities
+        for mnemonic, amp, lag, t_mean in constants.iec_mnemonics:
+            telem_times, telem_values = iecvals[mnemonic]
+            # Plot the measurements
+            lines = axes[0].plot(telem_times.plot_date, telem_values, marker='+', ls='none', label=mnemonic+" measurements")
+            # Plot the continuous curves interpolated smoothly between the measured values
+            axes[0].plot(plot_times.plot_date, interpolators[mnemonic](plot_times.mjd),
+                         color=lines[0].get_color())
+            # Plot the shifted version that we actually gets used in making the IEC calc
+            shifted_iecval = interpolators[mnemonic]((times_array - lag*astropy.units.minute).mjd)
+            axes[0].plot(times_array.plot_date, shifted_iecval, color=lines[0].get_color(), marker='.', ls='none',
+                         label=f"{mnemonic}, with {lag} min lag")
+
+        axes[0].set_ylabel("Temp [K]")
+        axes[0].set_title("Instrument Electronics Compartment (IEC) temperature telemetry", fontweight='bold')
+
+        # Plot the IEC WFE at the requested time points
+        axes[1].plot(times_array.plot_date, iec_wfe_coeff, color='black', marker='o', ls='none',
+                     label='Interpolated IEC WFE Coefficient')
+        # Plot the IEC WFE as a continous smooth curve
+        axes[1].plot(plot_times.plot_date, interpolate_iec_wfe_coeff(plot_times), color='black', )
+        axes[1].set_title("Inferred OTE WFE based on IEC thermal-to-WFE model", fontweight='bold')
+        axes[1].set_ylabel("WFE coeff [nm]")
+        axes[1].set_xlim(*axes[0].get_xlim())
+        axes[1].set_ylim(-3, 3)
+        for ax in axes:
+            ax.legend(loc='upper right')
+            ax.xaxis.axis_date()
+            ax.set_xlabel("Time [UTC]")
+        plt.tight_layout()
+
+    return iec_wfe_coeff
+
 
 
 # --------------------------------------------------------------------------------

--- a/stpsf/tests/test_opds.py
+++ b/stpsf/tests/test_opds.py
@@ -664,7 +664,7 @@ def test_iec_wfe_model():
 
     # Test calling the interpolator function with a single time as a string
     time_test = '2025-07-25T12:00:00'   # This time happens to have iec_coeff right around -2
-    iec_coeff = stpsf.opds.estimate_iec_induced_wfe_at_time(time_test)
+    iec_coeff = stpsf.opds.estimate_iec_induced_wfe_at_time(time_test, plot=True)   # also test here the plot option in that function in mast_wss
     assert np.isclose(iec_coeff, -2, rtol=0.01)
 
     ote.apply_iec_drift(iec_coeff)

--- a/stpsf/tests/test_opds.py
+++ b/stpsf/tests/test_opds.py
@@ -653,6 +653,7 @@ def test_get_rms_per_segment():
 
         assert np.isclose(rms_per_seg[seg], ote.rms(seg))
 
+@pytest.mark.importorskip('jwst')  # The IEC telemetry retrieval functionality requires the JWST pipeline
 def test_iec_wfe_model():
     import astropy.time
     ote = stpsf.opds.OTE_Linear_Model_WSS()

--- a/stpsf/tests/test_opds.py
+++ b/stpsf/tests/test_opds.py
@@ -653,8 +653,8 @@ def test_get_rms_per_segment():
 
         assert np.isclose(rms_per_seg[seg], ote.rms(seg))
 
-@pytest.mark.importorskip('jwst')  # The IEC telemetry retrieval functionality requires the JWST pipeline
 def test_iec_wfe_model():
+    jwst = pytest.importorskip('jwst')  # The IEC telemetry retrieval functionality requires the JWST pipeline
     import astropy.time
     ote = stpsf.opds.OTE_Linear_Model_WSS()
 

--- a/stpsf/tests/test_opds.py
+++ b/stpsf/tests/test_opds.py
@@ -652,3 +652,25 @@ def test_get_rms_per_segment():
             assert 10 < rms_per_seg[seg] < 100
 
         assert np.isclose(rms_per_seg[seg], ote.rms(seg))
+
+def test_iec_wfe_model():
+    import astropy.time
+    ote = stpsf.opds.OTE_Linear_Model_WSS()
+
+    # Test applying 1 nm rms of IEC-pattern astigmatism
+    ote.apply_iec_drift(1)
+    assert np.isclose(ote.rms(), 0.97, rtol=0.01), "OTE WFE RMS for this test case should be just under 1 nm RMS"
+
+    # Test calling the interpolator function with a single time as a string
+    time_test = '2025-07-25T12:00:00'   # This time happens to have iec_coeff right around -2
+    iec_coeff = stpsf.opds.estimate_iec_induced_wfe_at_time(time_test)
+    assert np.isclose(iec_coeff, -2, rtol=0.01)
+
+    ote.apply_iec_drift(iec_coeff)
+    assert np.isclose(ote.rms(), 0.97*2, rtol=0.01), "OTE WFE RMS for this test case should be just under 2 nm RMS"
+
+    # Test calling with a range of times as an array Time object
+    # Also test plotting
+    times = astropy.time.Time(time_test) + np.arange(60)*5*astropy.units.second
+    iec_coeffs = stpsf.opds.estimate_iec_induced_wfe_at_time(times, plot=True)
+    assert np.isclose(iec_coeff, iec_coeffs[0], rtol=0.01), "These values should be similar"


### PR DESCRIPTION
This PR implements a model for the IEC-driven WFE, as described in Telfer et al. 2024. This includes: 

 - Retrieval from MAST of the relevant IEC heater telemetry during a specified time range
 - Calculation of the IEC astigmatism coefficient, following the method described in Randal's paper. (using a slightly updated set of coefficients he provided, more recent than that paper)
 - Using that coefficient and the known pattern of segment PTTs characteristic of this mode to update the OTE WFE model. 

This model replaces the prior pre-flight IE model.

Example code:
```
    time = '2025-08-01T12:00:00'  
    iec_coeff = stpsf.opds.estimate_iec_induced_wfe_at_time(time)

    nrc = stpsf.NIRCam()
    nrc, ote = stpsf.enable_adjustable_ote(nrc)
    
    ote.apply_iec_drift(iec_coeff)

```

The `estimate_iec_induced_wfe_at_time` function will work on vector inputs for `time` to return a vector of IEC WFE amplitude over time, for cases where one wants to compute a time series of PSFs with this small variation.  

That function also has a `plot=True` keyword, to display how it's working behind the scenes: 
```
stpsf.opds.estimate_iec_induced_wfe_at_time('2025-08-18T00:00:00', plot=True)
```
<img width="1116" height="776" alt="Screenshot 2025-08-18 at 11 33 47 PM" src="https://github.com/user-attachments/assets/ce5d65e6-940a-4059-acea-8fad09482f44" />



**TO DO:** I still need to write some brief user documentation on this. Should that be added to an existing page in the docs, and if so which one, or should it be a new page just for this? Suggestions welcome. 
