### PR TITLE
added large psf pupil update for miri and minor charge difusion term …

### DIFF
--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -388,7 +388,7 @@ INSTRUMENT_DETECTOR_CHARGE_DIFFUSION_DEFAULT_PARAMETERS = {
     'NIRSPEC': 0.036,
     'MIRI': 0.001,  # Fit by Marshall + Marcio to ePSFs, after adding IPC
     #  0.070 Based on user reports, see issue #674. However, this was before adding IPC effects
-    'WFI': 0.0,  # Placeholder variable. Needs value update. Edit log message when sigma == 0 in detectors.apply_detector_charge_diffusion() after update.
+    'WFI': 0.033,  # 20250919 Value from Goddard recommendation (stpsf issue #111)
     'ROMANCORONAGRAPH': 0.0
 }
 # add Interpixel capacitance (IPC) effects. These are the parameters for each detector kernel

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -241,8 +241,8 @@ def apply_detector_charge_diffusion(psf_hdulist, options):
 
     if sigma == 0:
         stpsf.stpsf_core._log.info('Detector charge diffusion not applied '
-                                   'because charge_diffusion_sigma option is '
-                                   f"{'0' if inst !=' WFI' else '0 or None'}")
+                                   'because charge_diffusion_sigma option is 0'
+                                   )
         return psf_hdulist
 
     ext = 1  # Apply to the 'OVERDIST' extension

--- a/stpsf/optics.py
+++ b/stpsf/optics.py
@@ -11,6 +11,7 @@ import poppy.utils
 from astropy.table import Table
 from scipy.interpolate import RegularGridInterpolator, griddata
 from scipy.ndimage import rotate
+from scipy.ndimage import zoom
 
 from . import constants, utils, stpsf_core
 
@@ -1408,11 +1409,13 @@ class WebbFieldDependentAberration(poppy.OpticalElement):
                 # to 1024
                 self.amplitude = self.amplitude[256: 256 + 1024, 256: 256 + 1024]
             elif self.instrument.name == 'MIRI':
-                self.amplitude = fits.getdata(
+                amplitude_nominal = fits.getdata(
                     os.path.join(
                         utils.get_stpsf_data_path(), 'MIRI', 'optics', 'MIRI_tricontagon_oversized_rotated.fits.gz'
                     )
                 )
+                # this will adjust the amplitude size according to the opd size
+                self.amplitude = zoom(amplitude_nominal, npix / 1024)
 
             else:
                 # internal pupil is a 4 percent oversized circumscribing circle?

--- a/stpsf/optics.py
+++ b/stpsf/optics.py
@@ -1415,7 +1415,7 @@ class WebbFieldDependentAberration(poppy.OpticalElement):
                     )
                 )
                 # this will adjust the amplitude size according to the opd size
-                self.amplitude = zoom(amplitude_nominal, npix / 1024)
+                self.amplitude = amplitude_nominal if npix==1024 else zoom(amplitude_nominal, npix / 1024)
 
             else:
                 # internal pupil is a 4 percent oversized circumscribing circle?


### PR DESCRIPTION
This PR enhance support for a large PSF calculation for MIRI by resampling the tricontagon amplitude, previously hardcoded to 1024x1024 in size. 
I am also using this PR to update Roman WFI charge diffusion value from zero to 0.033 mas (see #111)
Example code for the MIRI large PSF using a larger 4x JWST pupil:
```
miri = stpsf.NIRCam()
miri.pupil = 'jwst_pupil_RevW_npix4096.fits.gz'
miri.load_wss_opd_by_date('2024-08-01T00:00:00')  
single_stpsf_larger_pupil = miri.calc_psf(fov_pixels = 2048)   
```
<img width="988" height="967" alt="image" src="https://github.com/user-attachments/assets/9216a216-c8a6-4031-a8b4-22df25b928f7" />

