### PR TITLE
 Improve NIRCam coron SI WFE model, based on empirical testing

### DIFF
--- a/stpsf/optics.py
+++ b/stpsf/optics.py
@@ -1434,6 +1434,15 @@ class WebbFieldDependentAberration(poppy.OpticalElement):
             self.opd = poppy.zernike.opd_from_zernikes(coeffs, npix=npix, outside=0)
             self.amplitude = (self.opd != 0).astype(int)
 
+        # Special case for NIRCam coronagraphy: we need to flip the OPD model in the Y axis.
+        #   In this case we are using a lookup table of Zernike coefficients derived from Zemax models
+        #   and it has been empirically determined that there seems to be a coordinate system inconsistency
+        #   in that. Flipping that vertically in the Y axis results in model PSFs that better match
+        #   observed coronagraphic PSFs.
+        if is_nrc_coron:
+            self.opd = self.opd[::-1]
+            self._is_OPD_flipped_for_NRC_coron = True
+
     def header_keywords(self):
         """Return info we would like to save in FITS header of output PSFs"""
         from collections import OrderedDict

--- a/stpsf/tests/test_nircam.py
+++ b/stpsf/tests/test_nircam.py
@@ -158,6 +158,11 @@ def do_test_nircam_blc(clobber=False, kind='circular', angle=0, save=False, disp
         else:
             raise ValueError("Don't know how to check fluxes for angle={0}".format(angle))
 
+    # we also verify that the SI WFE has been flipped in the Y axis in this case, as needed for NIRCam coronagraphy
+    osys = nc.get_optical_system()
+    si_wfe = osys.planes[-2]
+    assert si_wfe._is_OPD_flipped_for_NRC_coron, "The SI OPD model derived from Zemax should be flipped in this case"
+
     # If you change either of the following, the expected flux values will need to be updated:
     nlam = 1
     oversample = 4
@@ -323,6 +328,11 @@ def test_nircam_coron_unocculted(plot=False):
 
     # This test just verifies that calc_psf() runs without error
     nc.calc_psf(monochromatic=2.12e-6)
+
+    # we also verify that the SI WFE has been flipped in the Y axis in this case, as needed for NIRCam coronagraphy
+    osys = nc.get_optical_system()
+    si_wfe = osys.planes[-2]
+    assert si_wfe._is_OPD_flipped_for_NRC_coron, "The SI OPD model derived from Zemax should be flipped in this case"
 
 
 def test_defocus(fov_arcsec=1, display=False):

--- a/stpsf/tests/test_nircam.py
+++ b/stpsf/tests/test_nircam.py
@@ -468,10 +468,10 @@ def test_nircam_coron_wfe_offset(fov_pix=15, oversample=2, fit_gaussian=True):
             yloc.append(xvals[yvals == yvals.max()][0])
     yloc = np.array(yloc)
 
-    # Difference from 2.5 to 3.3 um should be ~0.025mm
+    # Difference from 2.5 to 3.3 um should be ~0.025mm. Updated to ~0.030 mm in PR #125 based on SI WFE model updates
     diff_25_33 = np.abs(yloc[0] - yloc[1])
     assert np.allclose(
-        diff_25_33, 0.025, rtol=rtol
+        diff_25_33, 0.030, rtol=rtol
     ), 'PSF shift between {:.2f} and {:.2f} um of {:.3f} mm does not match expected value (~0.025 mm).'.format(
         warr[1], warr[0], diff_25_33
     )


### PR DESCRIPTION
For NIRCam coronagraphy only, the SI WFE model is derived from optical modeling calculations in Zemax rather than ground test data. We've known this is imperfect for a while and there have been systematic issues in the PSF models that can easily be seen. 

Empirical testing and PSF comparisons by @kdlawson have recently shown that the PSF models can be significantly improved by simply flipping the SI WFE model in the vertical direction.  This PR implements such a flip, for NIRCam coron WFE _only_.   There are multiple ways such a fix could have been implemented; in this case I chose to do so with a change in code, rather than a change in the data file, because I judged that this is the easier way to roll out a change immediately and consistently to anyone using the `develop` version of STPSF. 

This only needs a pretty small & simple code change. 

Here's Kellen's discovery, copied here from a Slack discussion. 

@kdlawson wrote: 
> The first attached GIF flips between the final derotated image of HR 4796B in F444W+MASK335R and the best-fit nominal STPSF model. I'm not tuning distortion or pupil shear, etc — just source position and brightness. You can see the previously discussed halo/shadowing that differs significantly between the data and the nominal model.
The second GIF makes the same comparison but now using a model where I've literally just subclassed stpsf.NIRCam to flip the SI WFE OPD along the y-axis
> With no other tuning, chisq is reduced by a factor of ~2.5 with the flipped SI WFE model!

[Ed. note: Github is making these images huge, not sure why]

![hr4796b_nominal_stpsf_fit_noresids](https://github.com/user-attachments/assets/90e4f8a9-62bc-4d65-a20d-d76265dc13d0)
![hr4796b_flippedsiwfe_stpsf_fit_noresids](https://github.com/user-attachments/assets/e4186654-e7f0-4528-aac2-10bea7105e37)

The same improvement is also seen for NIRCam SW. Again from @kdlawson:
> SW definitely sees an improvement with the vertical SI WFE flip, at least. The "data" frame in each case is actually the empirical HPFRDI PSF model for HR 4796A, rather than the target itself (because the disk is very bright).
There's still some obvious inaccuracy in the flipped SI WFE version (2nd GIF), but it's worth noting that the latter is using the pupil shear fit with the nominal PSF models. Refitting pupil shear would likely clean this up even more. In any case, the shape of the speckles is obviously improved substantially here by flipping the SI WFE.

![hr4796a_F200W_MASK335R_nominal_stpsf_fit_noresids](https://github.com/user-attachments/assets/7d20522d-a159-4382-90de-c9a2150eadc3)
![hr4796a_F200W_MASK335R_flippedsiwfe_stpsf_fit_noresids](https://github.com/user-attachments/assets/7cef1513-11e2-42a6-987b-7c865893e503)

