### PR TITLE
very minor: quiet astropy warning for one plot. 

### DIFF
--- a/stpsf/trending.py
+++ b/stpsf/trending.py
@@ -184,7 +184,7 @@ def wavefront_time_series_plot(
 
     ax.set_xlim(start_date.plot_date, end_date.plot_date)
 
-    if end_date - start_date < 365:
+    if end_date - start_date < 365*u.day:
         ax.xaxis.set_major_locator(matplotlib.dates.WeekdayLocator(interval=1))
         ax.xaxis.set_minor_locator(matplotlib.dates.DayLocator())
     else:


### PR DESCRIPTION
Trivial PR to quiet a warning. The function `stpsf.trending.wavefront_time_series_plot` currently emits a "WARNING: TimeDeltaMissingUnitWarning". This fixes that. 

<img width="910" height="822" alt="Screenshot 2025-12-02 at 10 20 34 AM" src="https://github.com/user-attachments/assets/bb520ff3-e3bf-49e5-af3a-7894dc1f22d9" />
