### PR TITLE
update query range in MAST WSS OPD query for 4 day WFS cadence

### DIFF
--- a/stpsf/mast_wss.py
+++ b/stpsf/mast_wss.py
@@ -87,8 +87,10 @@ def mast_wss_opds_around_date_query(date, verbose=True):
 
     # Set date range (units of days) for the query
     # Note: start with a small value (+-1.5 day) so the MAST query doesn't start off too large
-    # This is consistent with expected WFS cadence
-    tdelta = TimeDelta(1.5 * u.day, format='jd')
+    # This is consistent with expected WFS cadence.
+    # Increase to +- 3 days after 2024 Dec, when the WFS cadence changed to every 4 days
+    drange = 1.5 if date < Time('2024-12-01') else 3
+    tdelta = TimeDelta(drange * u.day, format='jd')
 
     # With a too-small date range, this initial query may return a "NoResultsWarning"
     obs_table = mast_wss_date_query(date, tdelta)


### PR DESCRIPTION
Tiny PR. Updates the search range for finding OPDs to use a 2x larger search time period for recent dates, after the WFS cadence switched from 2 days to 4 days. 

The code works as is, but will often issue warnings like: 
```
WARNING: NoResultsWarning: Query returned no results. [astroquery.mast.discovery_portal]
iterating query, tdelta=3.0
```
This quiets that initial warning by just starting out with a ±3 days search range for recent dates. 
