### PR TITLE
add match_source_position option for setup_sim_to_match_file

### DIFF
--- a/stpsf/match_data.py
+++ b/stpsf/match_data.py
@@ -129,28 +129,51 @@ Configured simulation instrument for:
     if match_source_position:
         # we do this using jwst datamodels so we can invoke the gWCS
         import jwst.datamodels, astropy.units as u
+        print(filename_or_HDUList, jwst.datamodels.__path__)
         model = jwst.datamodels.open(filename_or_HDUList)
-        # What is the coordinate location of the target set in APT, as of the epoch of observations?
-        targ_coords = astropy.coordinates.SkyCoord(model.meta.target.ra,
-                                    model.meta.target.dec,
-                                    frame='icrs', unit=u.deg)
-        # where does that show up in the FITS file
-        targ_pos = model.meta.wcs.world_to_pixel(targ_coords)
-        targ_pos_integer_part = np.asarray(np.round(targ_pos), int)
-        targ_pos_subpix_part = targ_pos - targ_pos_integer_part
 
-        inst.detector_position = targ_pos_integer_part
-        inst.options['source_offset_x'] = targ_pos_subpix_part[0] * inst.pixelscale
-        inst.options['source_offset_y'] = targ_pos_subpix_part[1] * inst.pixelscale
-        if verbose:
-            print(f"""    Attempting to match target position precisely...
-    Target RA, Dec from file header: {targ_coords.to_string('hmsdms')}
-    Based on WCS that is at pixel coords {targ_pos}
-    Setting Det. Pos.: {inst.detector_position} {'in subarray' if not is_full_frame else ""}
-    Setting subpixel offset: {targ_pos_subpix_part} pixels = {targ_pos_subpix_part[0] * inst.pixelscale:.3f}, {targ_pos_subpix_part[1] * inst.pixelscale:.3f} arcsec.
-    """)
+        try:
+            if not hasattr(model.meta, 'wcs'):
+                raise astropy.wcs.WcsError("The selected file does not appear to have WCS metadata. Cannot use match_source_position.")
+            print(model.meta.wcs)
+            # What is the coordinate location of the target set in APT, as of the epoch of observations?
+            targ_coords = astropy.coordinates.SkyCoord(model.meta.target.ra,
+                                        model.meta.target.dec,
+                                        frame='icrs', unit=u.deg)
+            # where does that show up in the FITS file
+            targ_pos = model.meta.wcs.world_to_pixel(targ_coords)
+            targ_pos_integer_part = np.asarray(np.round(targ_pos), int)
+            targ_pos_subpix_part = targ_pos - targ_pos_integer_part
+            asdasd
+            if verbose:
+                print(f"""    Attempting to match target position precisely...
+        Target RA, Dec from file header: {targ_coords.to_string('hmsdms')}
+        Based on WCS that is at pixel coords {targ_pos}""")
 
-
+            # need to check for invalid coords, which may either be floats outside the allowed detector range
+            # or may be NaNs. (Depending on astropy version, or input files, or other context?)
+            if np.any(np.isnan(targ_pos)):
+                raise ValueError("coords should not be NaNs")
+            inst.detector_position = targ_pos_integer_part
+            inst.options['source_offset_x'] = targ_pos_subpix_part[0] * inst.pixelscale
+            inst.options['source_offset_y'] = targ_pos_subpix_part[1] * inst.pixelscale
+            if verbose:
+                print(f"""        Setting Det. Pos.: {inst.detector_position} {'in subarray' if not is_full_frame else ""}
+        Setting subpixel offset: {targ_pos_subpix_part} pixels = {targ_pos_subpix_part[0] * inst.pixelscale:.3f}, {targ_pos_subpix_part[1] * inst.pixelscale:.3f} arcsec.
+        """)
+        except ValueError:
+            # Can't set detector position; coords probably outside detector,
+            if verbose:
+                print(f"""    **Unable to set detector position: invalid coordinates!
+        Target may be outside of this file's image area, for instance in another detector or offset outside of the FOV
+        Leaving detector coordinates at default position: {inst.detector_position} {'in subarray' if not is_full_frame else ""}
+        """)
+        except astropy.wcs.WcsError:
+            # Can't set detector position due to WCS issue.
+            if verbose:
+                print(f"""    **Unable to set detector position: File lacks a valid WCS.
+        Leaving detector coordinates at default position: {inst.detector_position} {'in subarray' if not is_full_frame else ""}
+        """)
 
     return inst
 

--- a/stpsf/match_data.py
+++ b/stpsf/match_data.py
@@ -1,4 +1,5 @@
 # Functions to match or fit PSFs to observed JWST data
+import numpy as np
 import astropy
 import astropy.io.fits as fits
 import pysiaf
@@ -6,7 +7,8 @@ import pysiaf
 import stpsf
 
 
-def setup_sim_to_match_file(filename_or_HDUList, verbose=True, plot=False, choice='closest'):
+def setup_sim_to_match_file(filename_or_HDUList, verbose=True, plot=False, choice='closest',
+                            match_source_position=False):
     """Setup a stpsf Instrument instance matched to a given dataset
 
     Parameters
@@ -19,6 +21,16 @@ def setup_sim_to_match_file(filename_or_HDUList, verbose=True, plot=False, choic
         plot?
     choice : string
         Method to choose which OPD file to use, e.g. 'before', 'after', or 'closest'
+    match_source_position : bool
+        Set up the model to match the inferred coordinates of the science target in that image?
+        Specifically, use the FITS header to look up the target RA and Dec, then use the WCS
+        to determine where in pixel coordinates that RA, Dec is located. Set up the STPSF
+        instrument to have the detector_position attribute at that position (rounded to integer pixels),
+        and set the source_offset_x/y options for the remaining subpixel position.
+        Note, actually achieving subpixel alignment  will very likely need further adjustment of the
+        source_offset_x/y values manually, depending on the acheived precision of the WCS in your data.
+        If not set, the target position will be set to the default reference position of the relevant
+        aperture, which is typically the center of the full frame or center of a subarray.
     """
     if isinstance(filename_or_HDUList, str):
         if verbose:
@@ -98,6 +110,8 @@ def setup_sim_to_match_file(filename_or_HDUList, verbose=True, plot=False, choic
     # TODO add other per-instrument keyword checks
 
     if verbose:
+        is_full_frame = (inst.aperturename == 'NIS_CEN') if inst.name == 'NIRISS' else ('FULL' in inst.aperturename)
+
         print(
             f"""
 Configured simulation instrument for:
@@ -105,11 +119,38 @@ Configured simulation instrument for:
     Filter: {inst.filter}
     Detector: {inst.detector}
     Apername: {inst.aperturename}
-    Det. Pos.: {inst.detector_position} {'in subarray' if "FULL" not in inst.aperturename else ""}
+    Det. Pos.: {inst.detector_position} {'in subarray' if not is_full_frame else ""}
     Image plane mask: {inst.image_mask}
     Pupil plane mask: {inst.pupil_mask}
     """
         )
+
+    # Should we try to match the source position more exactly in that image, taking into account dithers etc?
+    if match_source_position:
+        # we do this using jwst datamodels so we can invoke the gWCS
+        import jwst.datamodels, astropy.units as u
+        model = jwst.datamodels.open(filename_or_HDUList)
+        # What is the coordinate location of the target set in APT, as of the epoch of observations?
+        targ_coords = astropy.coordinates.SkyCoord(model.meta.target.ra,
+                                    model.meta.target.dec,
+                                    frame='icrs', unit=u.deg)
+        # where does that show up in the FITS file
+        targ_pos = model.meta.wcs.world_to_pixel(targ_coords)
+        targ_pos_integer_part = np.asarray(np.round(targ_pos), int)
+        targ_pos_subpix_part = targ_pos - targ_pos_integer_part
+
+        inst.detector_position = targ_pos_integer_part
+        inst.options['source_offset_x'] = targ_pos_subpix_part[0] * inst.pixelscale
+        inst.options['source_offset_y'] = targ_pos_subpix_part[1] * inst.pixelscale
+        if verbose:
+            print(f"""    Attempting to match target position precisely...
+    Target RA, Dec from file header: {targ_coords.to_string('hmsdms')}
+    Based on WCS that is at pixel coords {targ_pos}
+    Setting Det. Pos.: {inst.detector_position} {'in subarray' if not is_full_frame else ""}
+    Setting subpixel offset: {targ_pos_subpix_part} pixels = {targ_pos_subpix_part[0] * inst.pixelscale:.3f}, {targ_pos_subpix_part[1] * inst.pixelscale:.3f} arcsec.
+    """)
+
+
 
     return inst
 


### PR DESCRIPTION
The function `setup_sim_to_match_file` has been setting the `detector_position` attribute to be the center of the detector (or center of subarray, etc, depending on the aperture name). The target may not necessarily be located there, particularly for dithered images. 

This PR adds a new keyword `match_source_position` to that function, which uses the FITS header TARG_RA, TARG_DEC and the WCS keywords to figure out the pixel coordinates where the target is expected to be, and it sets up the simulation instance to have detector_position set to that, rounded to integer pixels.  (It also attempts to set sub pixel position using source_offset, even though this probably won't be precise enough in many cases)

Questions: 
1. Should this maybe be turned on by default? For now I have left it off by default, for back compatibility so that existing code doesn't get unexpected changes of behaviors. But there's a case to me made that this might as well be on by default in general. ? 
2. Is trying to set sub pixel position with source offsets helpful, or confusing and unnecessary? Should there be a separate option to toggle this part on and off?  This can only be as good as the WCS, which is not in general always going to be precise enough at a sub pixel level. 

Example: 
```
In [3]:  miri = stpsf.setup_sim_to_match_file('jw01193062001_02101_00001_mirimage
      ⋮ _cal.fits', match_source_position=True)

Setting up sim to match jw01193062001_02101_00001_mirimage_cal.fits
iterating query, tdelta=3.0

MAST OPD query around UTC: 2022-11-13T06:57:01.514
                        MJD: 59896.28960085648

OPD immediately preceding the given datetime:
	URI:	 mast:JWST/product/R2022111308-NRCA3_FP1-1.fits
	Date (MJD):	 59896.0177
	Delta time:	 -0.2719 days

OPD immediately following the given datetime:
	URI:	 mast:JWST/product/R2022111503-NRCA3_FP1-1.fits
	Date (MJD):	 59898.0069
	Delta time:	 1.7173 days
User requested choosing OPD time closest in time to 2022-11-13T06:57:01.514, which is R2022111308-NRCA3_FP1-1.fits, delta time -0.272 days
Importing and format-converting OPD from /Users/mperrin/software/webbpsf-data/MAST_JWST_WSS_OPDs/R2022111308-NRCA3_FP1-1.fits
Backing out SI WFE and OTE field dependence at the WF sensing field point (NRCA3_FP1)
Sensing inst model using apername NRCA3_FP1
Using sensing field point SI WFE model from file wss_target_phase_fp1.fits

Configured simulation instrument for:
    Instrument: MIRI
    Filter: F2550W
    Detector: MIRIM
    Apername: MIRIM_BRIGHTSKY
    Det. Pos.: (256, 256) in subarray
    Image plane mask: None
    Pupil plane mask: None

```
**new part starts here:**
```

    Attempting to match target position precisely...
    Target RA, Dec from file header: 22h42m22.087s -29d21m39.77s
    Based on WCS that is at pixel coords [326.027730802757, 196.1974238785417]
    Setting Det. Pos.: (326, 196) in subarray
    Setting subpixel offset: [0.0277308  0.19742388] pixels = 0.003, 0.022 arcsec.
```