### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest",
+    "pytest>=9.0",
     "pytest-astropy",
 ]
 docs = [
@@ -70,8 +70,8 @@ namespaces = false
 local_scheme = "no-local-version"
 write_to = "stpsf/version.py"
 
-[tool.pytest.ini_options]
-minversion = "2.2"
+[tool.pytest]
+minversion = "9.0"
 testpaths = [
     "stpsf/tests",
 ]
@@ -79,10 +79,10 @@ norecursedirs = [
     "build",
     "docs/_build",
 ]
-astropy_header = "true"
+astropy_header = true
 doctest_plus = "enabled"
 text_file_format = "rst"
-addopts = "-p no:warnings"
+addopts = ["-p no:warnings"]
 
 [tool.coverage.run]
 source = [


### PR DESCRIPTION
Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`