### PR TITLE
Trending time series - add program IDs for cycle 4 maintenance programs

### DIFF
--- a/stpsf/trending.py
+++ b/stpsf/trending.py
@@ -126,6 +126,7 @@ def wavefront_time_series_plot(
         4509,
     ]  # Cycle 2
     routine_pids += list(range(6689, 6699))  # Cycle 3
+    routine_pids += [4430, 7052, 7126, 7127, 7344, 7464]  # Cycle 4
 
     is_routine = np.asarray([int(v[1:6]) in routine_pids for v in opdtable[where_pre]['visitId']])
 


### PR DESCRIPTION
Trivial PR to add the list of cycle 4 WFS program IDs. The only effect of this is changing the color coding of the data points in `wavefront_time_series_plot` so the points show up blue (regular maintenance) instead of purple (MIMF and other non-routine WFS). 

It would probably make sense to revisit that color coding feature and just remove it entirely at this point, so as to not have to add a list of PIDs each cycle, but I'll leave that for another day. 