### PR TITLE
Update Roman to use latest preflight (post-SCIPA) pupil maps. 

### DIFF
--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -462,203 +462,6 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
         stpsf_core.SpaceTelescopeInstrument._calc_psf_format_output(self, result, options)
 
 
-class WFIPupilController:
-    """
-    This is a helper class for the WFI and is used to swap in
-    the correct pupil each time the detector is changed.
-    The pupil depends on pupil_mask, detector, and filter;
-    pupil_mask is set automatically upon the receipt of the
-    detector and filter values selected by the user in the WFI class.
-    Users should only interact with this class through the API provided
-    in the WFI class.
-
-    Parameters
-    ----------
-    datapath : string
-        Path to STPSF-WFI data files
-    """
-
-    def __init__(self, datapath):
-        self.set_base_path(datapath)
-
-        self._pupil = None
-        self._pupil_mask = None
-
-        # Flag to en-/disable automatic selection of the appropriate pupil_mask
-        self._auto_pupil = True
-
-        # Flag to en-/disable automatic selection of the appropriate pupil file
-        self._auto_pupil_mask = True
-
-    @property
-    def pupil(self):
-        """
-        The path to the FITS file containing pupil information for the
-        detector/filter combination sent from the WFI class. Cannot be
-        directly set by the user.
-        """
-        return self._pupil
-
-    @pupil.setter
-    def pupil(self, value):
-        raise AttributeError('Pupil cannot be directly specified. ' 'Use lock_pupil() instead.')
-
-    @property
-    def pupil_mask(self):
-        """
-        The corresponding mask for the filter sent from the WFI class.
-        (See WFI.pupil_mask_list for a list of valid filters.) Cannot
-        be directly set by the user.
-        """
-        return self._pupil_mask
-
-    @pupil_mask.setter
-    def pupil_mask(self, name):
-        raise AttributeError('Pupil mask cannot be directly specified. '
-                             'Use lock_pupil_mask() instead.')
-
-    def _get_pupil_mask(self, wfi_filter):
-        """
-        Returns the appropriate pupil mask for a given WFI filter.
-
-        Parameters
-        ----------
-        wfi_filter : string
-            See WFI.filter_list for a list of valid filters.
-        """
-        wfi_filter = wfi_filter.upper()
-
-        if wfi_filter in GRISM_FILTERS:
-            # As of Cycle 10, GRISM0 and GRISM1 are the only filters that share
-            # a set of pupil masks with each other
-            return 'GRISM'
-        else:
-            return wfi_filter
-
-    def set_base_path(self, datapath):
-        """
-        Sets the root directory of the path to STPSF's data files.
-        This should be set before this class is used.
-
-        Parameters
-        ----------
-        datapath : string
-            Path to STPSF-WFI data files
-        """
-        self._datapath = datapath
-        self._pupil_basepath = os.path.join(self._datapath, 'pupils')
-
-    def pupil_file_formatter(self, wfi_filter, detector):
-        """
-        Generate proper pupil filename given a filter and a detector.
-
-        Parameters
-        ----------
-        wfi_filter : string
-            See WFI.filter_list for a list of valid filters.
-
-        detector : string
-            See WFI.detector_list for a list of valid detectors.
-        """
-        if wfi_filter.upper().startswith('F'):
-            return f"RST_WIM_Filter_{wfi_filter}_{detector}.fits.gz"
-        elif wfi_filter.upper().startswith('GRISM'):
-            return f"RST_WSM_Grism_grism_{detector}.fits.gz"
-        elif wfi_filter.upper() == 'PRISM':
-            return f"RST_WSM_Prism_prism_{detector}.fits.gz"
-
-    def update_pupil(self, wfi_filter, detector):
-        """
-        Selects the specific pupil file corresponding with a detector
-        and filter combination sent from the WFI class. Also finds and
-        indirectly sets the proper pupil_mask in the process.
-
-        Parameters
-        ----------
-        wfi_filter : string
-            See WFI.filter_list for a list of valid filters.
-
-        detector : string
-            See WFI.detector_list for a list of valid detectors.
-        """
-        if not self._auto_pupil:
-            _log.info('Automatic pupil selection was locked; '
-                      'using user-provided pupil.')
-            return
-
-        if self._pupil_basepath is None:
-            raise Exception('update_pupil called before setting pupil file path')
-
-        # figure out proper mask based on filter (or use locked mask if enabled)
-        pupil_mask = self._get_pupil_mask(wfi_filter) if self._auto_pupil_mask else self.pupil_mask
-        pupil = os.path.join(self._pupil_basepath,
-                             self.pupil_file_formatter(pupil_mask, detector))
-
-        self._pupil_mask = pupil_mask
-        self._pupil = pupil
-
-        _log.info(
-            f"Using {'' if self._auto_pupil_mask else 'locked '}"
-            f"pupil mask '{pupil_mask}' and detector '{detector}'."
-        )
-
-    def lock_pupil(self, pupil_path):
-        """
-        Prevents the WFIPupilController class from dynamically updating
-        the path to the pupil on any changes to the detector or filter
-        selected in the WFI class. Instead, the path remains locked on
-        whichever `pupil_path` was provided to this method.
-
-        CAUTION: This is non-standard usage of the WFI class and may
-        lead to unexpected behavior.
-
-        Parameters
-        ----------
-        pupil_path : string
-            The custom path to your pupil file.
-        """
-        self._pupil_mask = None
-        self._pupil = pupil_path
-        self._auto_pupil = False
-
-    def unlock_pupil(self):
-        """
-        Undoes the effects of lock_pupil() and resets WFIPupilController
-        to its default state of updating the pupil whenever a detector
-        or filter is changed in the WFI class.
-        """
-        self._auto_pupil = True
-
-    def lock_pupil_mask(self, pupil_mask):
-        """
-        Prevents the WFIPupilController class from dynamically updating
-        the pupil mask on any changes to the filter selected in the WFI
-        class. Instead, the pupil mask remains locked on whichever
-        `pupil_mask` was provided to this method.
-
-        CAUTION: This is non-standard usage of the WFI class and may
-        lead to unexpected behavior.
-
-        Parameters
-        ----------
-        filter : string
-            See WFI.pupil_mask_list for a list of valid pupil masks.
-        """
-        if not self._auto_pupil:
-            raise Exception('Pupil is locked. Unlock pupil before locking pupil mask.')
-        else:
-            self._pupil_mask = pupil_mask
-            self._auto_pupil_mask = False
-
-    def unlock_pupil_mask(self):
-        """
-        Undoes the effects of lock_pupil_mask() and resets
-        WFIPupilController to its default state of updating the pupil
-        mask whenever filter is changed in the WFI class.
-        """
-        self._auto_pupil_mask = True
-
-
 class WFI(RomanInstrument):
     """
     WFI represents the Roman mission's Wide Field Imager.
@@ -677,11 +480,12 @@ class WFI(RomanInstrument):
         self._aberration_files = {}
         self._is_custom_aberration = False
         self._current_aberration_file = ''
+        self._auto_pupil = True
 
         super().__init__('WFI', pixelscale=pixelscale)
 
         # Initialize the pupil controller
-        self._pupil_controller = WFIPupilController(self._datapath)
+        #self._pupil_controller = WFIPupilController(self._datapath)
 
         self.pupil_mask_list = [fltr for fltr in self.filter_list.copy()
                                 if not fltr.startswith('GRISM')]
@@ -746,14 +550,19 @@ class WFI(RomanInstrument):
         super()._validate_config(**kwargs)
 
     def _update_pupil(self, wfi_filter=None, detector=None):
+        # The pupil geometry depends on field position,
+        # parameterized by SCA and field position number within the SCA
+
         if detector is None:
             detector = self.detector
         if wfi_filter is None:
             wfi_filter = self.filter
+        fn = f'RST_WFI_pupil_{wfi_filter}_WFI{detector[-2:]}_allfieldpoints.fits.gz'
 
-        if detector is not None and wfi_filter is not None:
-            self._pupil_controller.update_pupil(wfi_filter=wfi_filter,
-                                                detector=detector)
+        self._pupil_filename = os.path.join(self._datapath, 'pupils', fn)
+        _log.debug("Updating pupil filename to {self._pupil_filename}")
+        print(f"Updating pupil filename to {self._pupil_filename}")
+
 
     @RomanInstrument.detector.setter
     def detector(self, value):
@@ -769,9 +578,15 @@ class WFI(RomanInstrument):
             raise ValueError('Invalid detector. Valid detector names are: {}'.format(', '.join(self.detector_list)))
 
         self._detector = value.upper()
-        if self._detector is not None:
-            self._update_pupil(detector=self._detector)
+        if self._detector is not None and self._auto_pupil:
+            self._update_pupil()
         self._update_aperturename()
+
+    @RomanInstrument.detector_position.setter
+    def detector_position(self, position):
+        super().detector_position.__set__(self, position)
+        if self._detector is not None and self._auto_pupil:
+            self._update_pupil()
 
     def _update_aperturename(self):
         """Update SIAF aperture name after change in detector or other relevant properties.
@@ -857,8 +672,8 @@ class WFI(RomanInstrument):
 
         # Update pupil only if detector was previously loaded
         # ( i.e., skip this step when called by super() )
-        if self.detector is not None:
-            self._update_pupil(wfi_filter=self._filter)
+        if self.detector is not None and self._auto_pupil:
+            self._update_pupil()
 
     @property
     def pupil(self):
@@ -867,7 +682,7 @@ class WFI(RomanInstrument):
         detector/filter combination sent from the WFI class. Cannot be
         directly set by the user.
         """
-        return self._pupil_controller.pupil
+        return self._pupil_filename
 
     @pupil.setter
     def pupil(self, value):
@@ -886,7 +701,7 @@ class WFI(RomanInstrument):
 
     @pupil_mask.setter
     def pupil_mask(self, name):
-        raise AttributeError('Pupil mask cannot be directly specified. ' 'Use lock_pupil_mask() instead.')
+        raise AttributeError('Pupil mask cannot be directly specified. ')
 
     @property
     def mode(self):
@@ -953,68 +768,6 @@ class WFI(RomanInstrument):
         self._load_detector_aberrations(aberration_path)
         self._aberration_files['custom'] = None
         self._is_custom_aberration = False
-
-    def lock_pupil(self, pupil_path):
-        """
-        Prevents dynamic updates of the path to the proper pupil file on
-        any changes to the selected detector or filter. Instead, the
-        path remains locked on whichever `pupil_path` was provided here.
-
-        WARNING: This is non-standard usage of the WFI class and may
-        lead to unexpected behavior.
-
-        Parameters
-        ----------
-        pupil_path : string
-            The custom path to your pupil file.
-        """
-        if os.path.isfile(pupil_path):
-            self._pupil_controller.lock_pupil(pupil_path)
-        else:
-            raise FileNotFoundError(f'{pupil_path} not found.')
-
-        _log.warning('Disabling default pupil selection behavior.')
-
-    def unlock_pupil(self):
-        """
-        Undoes the effects of lock_pupil() by resetting the class to
-        its default state of updating the pupil whenever a detector or
-        filter is changed. If necessary, it also sets the proper pupil
-        for the current detector/filter combination.
-        """
-        self._pupil_controller.unlock_pupil()
-        self._update_pupil()  # reset pupil
-        _log.info('Restoring default pupil selection behavior.')
-
-    def lock_pupil_mask(self, pupil_mask):
-        """
-        Prevents dynamic updates of the pupil mask on any change to the
-        selected filter. Instead, the pupil mask remains locked on
-        whichever `pupil_mask` was provided here.
-
-        WARNING: This is non-standard usage of the WFI class and may
-        lead to unexpected behavior.
-
-        Parameters
-        ----------
-        filter : string
-            See WFI.pupil_mask_list for a list of valid pupil masks.
-        """
-        if pupil_mask not in self.pupil_mask_list:
-            raise Exception('invalid pupil mask')
-        self._pupil_controller.lock_pupil_mask(pupil_mask)
-        self._update_pupil()
-        _log.warning('Disabling default pupil mask selection behavior.')
-
-    def unlock_pupil_mask(self):
-        """
-        Undoes the effects of lock_pupil_mask() and resets the class to
-        its default state of updating the pupil mask whenever the filter
-        is changed.
-        """
-        self._pupil_controller.unlock_pupil_mask()
-        self._update_pupil()  # reset pupil mask
-        _log.info('Restoring default pupil mask selection behavior.')
 
 
 class RomanCoronagraph(RomanInstrument):

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -4,8 +4,8 @@ Roman Instruments
 =================
 
 WARNING: This model has not yet been validated against other PSF
-         simulations, and uses several approximations (e.g. for
-         mirror polishing errors, which are taken from HST).
+         simulations, and uses several approximations
+
 """
 
 import logging
@@ -465,10 +465,6 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
 class WFI(RomanInstrument):
     """
     WFI represents the Roman mission's Wide Field Imager.
-
-    WARNING: This model has not yet been validated against other PSF
-             simulations, and uses several approximations (e.g. for
-             mirror polishing errors, which are taken from HST).
     """
 
     def __init__(self):
@@ -480,7 +476,7 @@ class WFI(RomanInstrument):
         self._aberration_files = {}
         self._is_custom_aberration = False
         self._current_aberration_file = ''
-        self._auto_pupil = True
+        self.auto_pupil = True
 
         super().__init__('WFI', pixelscale=pixelscale)
 
@@ -507,8 +503,8 @@ class WFI(RomanInstrument):
         self._load_detector_aberrations(self._aberration_files[self.mode])
         self.detector = 'WFI01'
 
-        self.opd_list = [os.path.join(self._STPSF_basepath, 'upscaled_HST_OPD.fits')]
-        self.pupilopd = self.opd_list[-1]
+        self.opd_list = []
+        self.pupilopd = None
 
     def _addAdditionalOptics(self, optsys, **kwargs):
         _log.debug('   No optics added for WFI')
@@ -554,19 +550,22 @@ class WFI(RomanInstrument):
         # The pupil geometry depends on field position,
         # parameterized by SCA and field position number within the SCA
 
-        if self._detector is None or not self._auto_pupil:
+        if self._detector is None or not self.auto_pupil:
             # cannot update the pupil yet, class still being initialized
             # or else the auto_pupil has been disabled by the user
             return
 
         self.pupil_datacube_index = _wfi_sci_xy_to_fp(*self.detector_position)
 
-        pupil_filename = f'RST_WFI_pupil_{self.filter}_WFI{self.detector[-2:]}_allfieldpoints.fits.gz'
+        element = 'GRISM' if self.filter in GRISM_FILTERS else self.filter
+
+        pupil_filename = f'RST_WFI_pupil_{element}_WFI{self.detector[-2:]}_allfieldpoints.fits.gz'
         self._pupil_filename = os.path.join(self._datapath, 'pupils', pupil_filename)
-        _log.debug(f"Updating pupil filename to {self._pupil_filename}, field point {self.pupil_datacube_index} for {self.detector} {self.detector_position}")
+        _log.debug(f"Updating pupil filename to {self._pupil_filename}, field point {self.pupil_datacube_index} for "+
+                   f"{self.detector} {self.detector_position}")
 
         # TODO: Implement the filename for the high spatial frequency mirror info
-        highfreq_filename = f'RST_WFI_primary_highfreq_{self.filter}_WFI{self.detector[-2:]}.fits.gz'
+        highfreq_filename = f'RST_WFI_primary_highfreq_{element}_WFI{self.detector[-2:]}.fits.gz'
         self._pupilopd_filename = os.path.join(self._datapath, 'pupils', highfreq_filename)
         # TODO:
         # set self.pupilopd

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -484,12 +484,13 @@ class WFI(RomanInstrument):
 
         super().__init__('WFI', pixelscale=pixelscale)
 
-        # Initialize the pupil controller
-        #self._pupil_controller = WFIPupilController(self._datapath)
+        self._pupil_filename = None
+        self.pupil_datacube_index = None
 
-        self.pupil_mask_list = [fltr for fltr in self.filter_list.copy()
-                                if not fltr.startswith('GRISM')]
-        self.pupil_mask_list.append(np.str_('GRISM'))  # GRISM0/1 share pupils
+        self.pupil_mask_list = []
+        #fltr for fltr in self.filter_list.copy()
+        #                        if not fltr.startswith('GRISM')]
+        #self.pupil_mask_list.append(np.str_('GRISM'))  # GRISM0/1 share pupils
 
         # Define default aberration files for WFI filters
         self._aberration_files = {'custom': None}
@@ -549,19 +550,26 @@ class WFI(RomanInstrument):
         assert self.pupil is not None, 'pupil is None'
         super()._validate_config(**kwargs)
 
-    def _update_pupil(self, wfi_filter=None, detector=None):
+    def _update_pupil(self):
         # The pupil geometry depends on field position,
         # parameterized by SCA and field position number within the SCA
 
-        if detector is None:
-            detector = self.detector
-        if wfi_filter is None:
-            wfi_filter = self.filter
-        fn = f'RST_WFI_pupil_{wfi_filter}_WFI{detector[-2:]}_allfieldpoints.fits.gz'
+        if self._detector is None or not self._auto_pupil:
+            # cannot update the pupil yet, class still being initialized
+            # or else the auto_pupil has been disabled by the user
+            return
 
-        self._pupil_filename = os.path.join(self._datapath, 'pupils', fn)
-        _log.debug("Updating pupil filename to {self._pupil_filename}")
-        print(f"Updating pupil filename to {self._pupil_filename}")
+        self.pupil_datacube_index = _wfi_sci_xy_to_fp(*self.detector_position)
+
+        pupil_filename = f'RST_WFI_pupil_{self.filter}_WFI{self.detector[-2:]}_allfieldpoints.fits.gz'
+        self._pupil_filename = os.path.join(self._datapath, 'pupils', pupil_filename)
+        _log.debug(f"Updating pupil filename to {self._pupil_filename}, field point {self.pupil_datacube_index} for {self.detector} {self.detector_position}")
+
+        # TODO: Implement the filename for the high spatial frequency mirror info
+        highfreq_filename = f'RST_WFI_primary_highfreq_{self.filter}_WFI{self.detector[-2:]}.fits.gz'
+        self._pupilopd_filename = os.path.join(self._datapath, 'pupils', highfreq_filename)
+        # TODO:
+        # set self.pupilopd
 
 
     @RomanInstrument.detector.setter
@@ -578,15 +586,13 @@ class WFI(RomanInstrument):
             raise ValueError('Invalid detector. Valid detector names are: {}'.format(', '.join(self.detector_list)))
 
         self._detector = value.upper()
-        if self._detector is not None and self._auto_pupil:
-            self._update_pupil()
+        self._update_pupil()
         self._update_aperturename()
 
     @RomanInstrument.detector_position.setter
     def detector_position(self, position):
-        super().detector_position.__set__(self, position)
-        if self._detector is not None and self._auto_pupil:
-            self._update_pupil()
+        RomanInstrument.detector_position.fset(self, position)
+        self._update_pupil()
 
     def _update_aperturename(self):
         """Update SIAF aperture name after change in detector or other relevant properties.
@@ -670,10 +676,7 @@ class WFI(RomanInstrument):
             if not os.path.samefile(self._current_aberration_file, aberration_file):
                 self._load_detector_aberrations(aberration_file)
 
-        # Update pupil only if detector was previously loaded
-        # ( i.e., skip this step when called by super() )
-        if self.detector is not None and self._auto_pupil:
-            self._update_pupil()
+        self._update_pupil()
 
     @property
     def pupil(self):
@@ -697,7 +700,7 @@ class WFI(RomanInstrument):
         The corresponding mask for the current filter. Cannot be
         directly set by the user.
         """
-        return self._pupil_controller.pupil_mask
+        return None
 
     @pupil_mask.setter
     def pupil_mask(self, name):
@@ -1062,3 +1065,36 @@ class RomanCoronagraph(RomanInstrument):
         result[0].header.set('LSTRAN', os.path.basename(self._lyotstop_fname), comment='Lyot stop transmission')
         result[0].header.set('PUPLSCAL', lyotstop_hdr['PUPLSCAL'], comment='Lyot stop pixel scale in m/pixel')
         result[0].header.set('PUPLDIAM', lyotstop_hdr['PUPLDIAM'], comment='Lyot stop array size, incl padding.')
+
+
+def _wfi_sci_xy_to_fp(x, y):
+    """Convert from (x, y) in pixels to the field point numbering used for the Zernikes and pupil masks
+
+    Inverse of fp_to_sci_xy
+
+    Parameters
+    ----------
+    x, y : float
+        Pixel coordinates in Science frame. Values expected to be within 0-4096
+
+    Returns
+    -------
+    fp : int
+        Field point index from 1 to 25
+        """
+    n = 4096
+    vertical = np.round(4 * y / n + 1)
+    horizontal = np.round(4 * (n - x) / n)
+    fp = int(horizontal * 5 + vertical)
+    return fp
+
+
+def _wfi_fp_to_sci_xy(fp):
+    """Convert from field point number to Sci frame X, Y pixel coord
+
+    Inverse of sci_xy_to_fp
+    """
+    n = 4096
+    y = int(np.mod(fp - 1, 5) * n // 4)
+    x = int(4 - (fp - 1) // 5) * n // 4
+    return (x, y)

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -591,10 +591,14 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
                 pupil_transmission = self.pupil
             else:
                 raise TypeError('Not sure what to do with a pupil of ' 'that type: {}'.format(type(self.pupil)))
+            # ---- check if we have an index into a datacube; this is used for Roman
+            transmission_index = self.pupil_datacube_index if hasattr(self, 'pupil_datacube_index') else None
+
             # ---- apply pupil intensity and OPD to the optical model
             pupil_optic = poppy.FITSOpticalElement(
                 name='{} Entrance Pupil'.format(self.telescope),
                 transmission=pupil_transmission,
+                transmission_index = transmission_index,
                 opd=opd_map,
                 planetype=poppy.poppy_core.PlaneType.pupil,
                 # rotation=self._rotation

--- a/stpsf/tests/test_roman.py
+++ b/stpsf/tests/test_roman.py
@@ -11,14 +11,14 @@ GRISM_FILTERS = roman.GRISM_FILTERS
 PRISM_FILTERS = roman.PRISM_FILTERS
 
 
-def pupil_path(wfi, mask=None):
+def pupil_path(wfi):
     """
     dynamically generate current pupil path for a given WFI instance
     """
-    mask = wfi._pupil_controller._get_pupil_mask(wfi.filter) if mask is None else mask
+    element = 'GRISM' if wfi.filter in GRISM_FILTERS else wfi.filter
 
-    base = wfi._pupil_controller._pupil_basepath
-    file = wfi._pupil_controller.pupil_file_formatter(mask, wfi.detector)
+    base = wfi._datapath
+    file = f'pupils/RST_WFI_pupil_{element}_WFI{wfi.detector[-2:]}_allfieldpoints.fits.gz'
 
     return os.path.join(base, file)
 
@@ -83,72 +83,64 @@ def test_WFI_fwhm():
     assert 4.0 > fwhm_f184 / fwhm_f062 > 2.0
 
 
-def test_WFI_pupil_controller():
-    wfi = roman.WFI()
+def test_wfi_pupil_field_dependence():
+    """Test that it automatically loads different pupil based on detector and detector position
+     - The filename is selected based on detector and filter.
+     - The index into the datacube in that file is selected based on detector position
+    The expectation is there are a total of 25 field points (5x5) across each detector, with a particular
+    numbering and arrangement as used in the 2026 prelaunch data delivery.
+    Furthermore there are distinct sets of such files for each filter.
 
-    for detector in wfi.detector_list:
-        wfi.detector = detector
+    This test only iterates over a subset of filters and detectors and positions, because that
+    suffices to test the relevant functionalities in general.
 
-        assert os.path.isfile(pupil_path(wfi)), f'Pupil file missing: {pupil_path(wfi)}'
+    """
 
-        # Test detector change was successful
-        assert wfi.detector == detector, 'WFI detector was not set correctly'
-        assert wfi.pupil == pupil_path(wfi), 'pupil path was not set correctly'
+    elements = ['F087', "F184", 'PRISM']
+    dets = ['WFI01', 'WFI09', 'WFI18']
+    corners = np.asarray( [(0,0), (0, 1), (1,0), (1,1)]) * 4090
+    corner_field_point_expected = [21, 25, 1, 5]
 
-        # Test pupil mask lock/unlock
-        for mask in wfi.pupil_mask_list:
-            # test lock
-            wfi.lock_pupil_mask(mask)
+    for element in elements:
+        for det in dets:
+            wfi = roman.WFI()
+            wfi.filter = element
+            wfi.detector = det
+            assert wfi.detector_position == (2048, 2048), "Default detector position should be middle of the detector"
+            assert wfi.pupil_datacube_index == 13, "Default pupil datacube index should be middle of the 25 field points"
 
-            assert wfi.pupil == pupil_path(wfi, mask), 'Pupil path was not set correctly'
+            for (x,y), fp  in zip(corners, corner_field_point_expected):
+                wfi.detector_position = (x, y)
 
-            # introduce differing filter to modify
-            wfi.filter = 'PRISM' if mask != 'PRISM' else 'F062'
+                # Check that the wfi.pupil element updates as expected
+                assert det in wfi.pupil, "The pupil filename ought to update based on detector "
+                assert element in wfi.pupil, "The pupil filename ought to update based on filter"
+                assert wfi.pupil_datacube_index == fp, ("The pupil file datacube index did not match the"+
+                                                        f" expected field point: got {wfi.pupil_datacube_index} instead of {fp}")
 
-            assert wfi._pupil_controller._pupil_mask == wfi.pupil_mask, 'Pupil mask was not set correctly'
+                # Check that if we toggle off the auto_pupil feature then the pupil and datacube index stop changing.
+                selected_pupil_file = wfi.pupil
+                selected_pupil_cube_index = wfi.pupil_datacube_index
+                wfi.auto_pupil = False
+                wfi.detector_position = (512, 1536)
+                assert wfi.pupil_datacube_index == selected_pupil_cube_index, "Pupil file should not change with new det pos if auto_pupil is False"
+                assert wfi.pupil == selected_pupil_file, "Pupil file should not change with new det pos"
+                wfi.detector = 'WFI03'
+                assert wfi.pupil == selected_pupil_file, "Pupil file should not change with new detector if auto_pupil is False"
+                wfi.detector = det   # Reset before continuing the next part of the test
+                wfi.detector_position = (x, y)
 
-            # test unlock
-            wfi.unlock_pupil_mask()
+                # now re-enable auto_pupil and verify that it works as expected,
+                #   first for a change in detector position, then for a change in detector
+                wfi.auto_pupil = True
+                wfi.detector_position = (512, 1536)
+                assert wfi.pupil_datacube_index != selected_pupil_cube_index, "Pupil file should change with new det pos if auto_pupil is True"
+                assert wfi.pupil == selected_pupil_file, "Pupil file should not change with new det pos "
+                wfi.detector = 'WFI03'
+                assert wfi.pupil != selected_pupil_file, "Pupil file should change with new detector if auto_pupil is True"
+                wfi.detector = det   # Reset to current detector before continuing the for loop over field positions
 
-            assert wfi.pupil == pupil_path(wfi), 'Pupil mask unlock failed'
 
-        assert wfi._pupil_controller._auto_pupil, 'Pupil is locked and should not be'
-        assert wfi._pupil_controller._auto_pupil_mask, 'Pupil mask is locked and should not be'
-
-        # Test pupil lock/unlock
-        with pytest.raises(FileNotFoundError):
-            assert wfi.lock_pupil('file_that_does_not_exist.fits'), 'FileNotFoundError was not raised'
-
-        this_file = __file__
-        wfi.lock_pupil(this_file)
-        assert wfi.pupil == this_file, 'Pupil did not lock to proper file.'
-
-        wfi.unlock_pupil()
-        assert wfi.pupil == pupil_path(wfi), 'Pupil unlock failed.'
-
-        assert wfi._pupil_controller._auto_pupil, 'Pupil is locked and should  not be'
-        assert wfi._pupil_controller._auto_pupil_mask, 'Pupil mask is locked and should not be'
-
-        # Test effect of changing the filter on pupil path
-        for fltr in wfi.filter_list:
-            wfi.filter = fltr
-
-            assert wfi.pupil == pupil_path(wfi), f'Pupil was not set to correct value for filter {fltr}'
-
-    # Test persistence of pupil and pupil mask locks through a PSF calculation
-    wfi2 = roman.WFI()
-    wfi2.detector = detector
-    valid_pos = (4000, 1000)
-    wfi2.detector_position = valid_pos
-
-    wfi2.filter = 'F129'
-    wfi2.lock_pupil_mask('GRISM')
-    wfi2.filter = 'F129'
-    assert wfi2.pupil == pupil_path(wfi2, 'GRISM'), 'Pupil path was not set correctly'
-    wfi2.calc_psf(monochromatic=1.3e-6, fov_pixels=4)
-
-    assert wfi.pupil_mask == 'GRISM', 'Pupil mask changed during PSF calculation'
-    assert wfi2.pupil == pupil_path(wfi2, 'GRISM'), 'Pupil path changed during PSF calculation'
 
 
 def test_WFI_detector_position_setter():
@@ -323,3 +315,17 @@ def test_coronagraph_psf(display=False):
     monopsf = char_spc.calc_psf(nlambda=1, display=False)
     if display:
         roman.poppy.display_psf(monopsf)
+
+# -------- Test utility functions for WFI field of view position coordinate conversions
+
+
+def test_sci_xy_to_fp():
+    """Test corners match expectations"""
+    corner_data = ( ((0,0), 21), # lower left
+                    ((0, 4096), 25), # upper left
+                    ((4096, 0), 1), # lower right
+                    ((4096, 4096), 5) # upper right
+                  )
+    for (x, y), fp in corner_data:
+        assert roman._wfi_sci_xy_to_fp(x, y) == fp  # test xy->fp
+        assert roman._wfi_sci_xy_to_fp( *roman._wfi_fp_to_sci_xy(fp)) == fp , f'round trip error for fp {fp}'  # test round trip


### PR DESCRIPTION
-  [x] Update pupil filenames
-  [ ] Make pupil auto update on detector position changes, too
- [ ] Select correct slice of the datacubes
- [x] Remove pupil controller.
- [ ] Test