### PR TITLE
Fix astrometric distortion, cleanup code, and test better

### DIFF
--- a/stpsf/distortion.py
+++ b/stpsf/distortion.py
@@ -112,7 +112,6 @@ def distort_image(
     # Pixel scale information
     ny, nx = hdu_list[ext].shape
     pixelscale = hdu_list[ext].header['PIXELSCL']  # the pixel scale carries the over-sample value
-    osamp = hdu_list[ext].header['OVERSAMP']
 
     # Subtle issue: How to handle oversampling and pixel scale depends on context, and
     # in particular whether the user may have overridden the normal pixelscale with some custom

--- a/stpsf/distortion.py
+++ b/stpsf/distortion.py
@@ -137,7 +137,17 @@ def distort_image(
     pixelscale = hdu_list[ext].header['PIXELSCL']  # the pixel scale carries the over-sample value
     osamp = hdu_list[ext].header['OVERSAMP']
 
+    # Subtle issue: How to handle oversampling and pixel scale depends on context, and
+    # in particular whether the user may have overridden the normal pixelscale with some custom
+    # value. If the simulated pixelscale does not match the actual SIAF pixelscale, then the
+    # oversampling relative to the SCI coordinate frame will not simply be the OVERSAMP keyword
+    # value. To accomodate that edge case, compute here the oversampling as the ratio of the
+    # computed pixelscale relative to the nominal average scale used in SIAF.
+    osamp = 0.5*(aper.XSciScale + aper.YSciScale) / pixelscale
+
     # Get 'sci' reference location where PSF is observed
+    xcen_sci = hdu_list[ext].header['DET_X']  # center x location in pixels ('sci')
+    ycen_sci = hdu_list[ext].header['DET_Y']  # center y location in pixels ('sci')
     xsci_cen = hdu_list[ext].header['DET_X']  # center x location in pixels ('sci')
     ysci_cen = hdu_list[ext].header['DET_Y']  # center y location in pixels ('sci')
 

--- a/stpsf/distortion.py
+++ b/stpsf/distortion.py
@@ -135,6 +135,7 @@ def distort_image(
     # Pixel scale information
     ny, nx = hdu_list[ext].shape
     pixelscale = hdu_list[ext].header['PIXELSCL']  # the pixel scale carries the over-sample value
+    osamp = hdu_list[ext].header['OVERSAMP']
 
     # Get 'sci' reference location where PSF is observed
     xsci_cen = hdu_list[ext].header['DET_X']  # center x location in pixels ('sci')
@@ -162,10 +163,8 @@ def distort_image(
             assert xnew_coords.shape == ynew_coords.shape, 'If new x and y inputs are a grid, must be same shapes'
             xnew, ynew = xnew_coords, ynew_coords
     elif to_frame == 'sci':
-        osamp_x = aper.XSciScale / pixelscale
-        osamp_y = aper.YSciScale / pixelscale
-        xnew = xarr / osamp_x + xnew_cen
-        ynew = yarr / osamp_y + ynew_cen
+        xnew = xarr / osamp + xnew_cen
+        ynew = yarr / osamp + ynew_cen
     else:
         # Get 'idl' coords
         xidl = xarr * pixelscale + xidl_cen

--- a/stpsf/distortion.py
+++ b/stpsf/distortion.py
@@ -52,8 +52,6 @@ def distort_image(
     ext=0,
     to_frame='sci',
     fill_value=0,
-    xnew_coords=None,
-    ynew_coords=None,
     return_coords=False,
     aper=None,
 ):
@@ -77,29 +75,8 @@ def distort_image(
         Value used to fill in any blank space by the skewed PSF. Default = 0.
         If set to None, values outside the domain are extrapolated.
     to_frame : str
-        Requested type of output coordinate frame.
-
-            * 'tel': arcsecs V2,V3
+        Requested type of output coordinate frame. DEPRECATED, now must be 'sci'
             * 'sci': pixels, in conventional DMS axes orientation
-            * 'det': pixels, in raw detector read out axes orientation
-            * 'idl': arcsecs relative to aperture reference location.
-
-    xnew_coords : None or ndarray
-        Array of x-values in new coordinate frame to interpolate onto.
-        Can be a 1-dimensional array of unique values, in which case
-        the final image will be of size (ny_new, nx_new). Or a 2d array
-        that corresponds to full regular grid and has same shape as
-        `ynew_coords` (ny_new, nx_new). If set to None, then final image
-        is same size as input image, and coordinate grid spans the min
-        and max values of siaf_ap.convert(xidl,yidl,'idl',to_frame).
-    ynew_coords : None or ndarray
-        Array of y-values in new coordinate frame to interpolate onto.
-        Can be a 1-dimensional array of unique values, in which case
-        the final image will be of size (ny_new, nx_new). Or a 2d array
-        that corresponds to full regular grid and has same shape as
-        `xnew_coords` (ny_new, nx_new). If set to None, then final image
-        is same size as input image, and coordinate grid spans the min
-        and max values of siaf_ap.convert(xidl,yidl,'idl',to_frame).
     return_coords : bool
         In addition to returning the final image, setting this to True
         will return the full set of new coordinates. Output will then
@@ -148,75 +125,44 @@ def distort_image(
     # Get 'sci' reference location where PSF is observed
     xcen_sci = hdu_list[ext].header['DET_X']  # center x location in pixels ('sci')
     ycen_sci = hdu_list[ext].header['DET_Y']  # center y location in pixels ('sci')
-    xsci_cen = hdu_list[ext].header['DET_X']  # center x location in pixels ('sci')
-    ysci_cen = hdu_list[ext].header['DET_Y']  # center y location in pixels ('sci')
 
     # Convert the PSF center point from pixels to arcseconds using pysiaf
-    xidl_cen, yidl_cen = aper.sci_to_idl(xsci_cen, ysci_cen)
+    xcen_idl, ycen_idl = aper.sci_to_idl(xcen_sci, ycen_sci)
 
     # ###############################################
     # Create an array of indices (in pixels) for where the PSF is located on the detector
     nx_half, ny_half = ((nx - 1) / 2.0, (ny - 1) / 2.0)
-    xlin = np.linspace(-1 * nx_half, nx_half, nx)
-    ylin = np.linspace(-1 * ny_half, ny_half, ny)
-    xarr, yarr = np.meshgrid(xlin, ylin)
+    xlin_pix = np.linspace(-1 * nx_half, nx_half, nx)
+    ylin_pix = np.linspace(-1 * ny_half, ny_half, ny)
+    xarr, yarr = np.meshgrid(xlin_pix, ylin_pix)
 
     # ###############################################
     # Create an array of indices (in pixels) that the final data will be interpolated onto
-    xnew_cen, ynew_cen = aper.convert(xsci_cen, ysci_cen, 'sci', to_frame)
-
-    # If new x and y values are specified, create a meshgrid
-    if (xnew_coords is not None) and (ynew_coords is not None):
-        if len(xnew_coords.shape) == 1 and len(ynew_coords.shape) == 1:
-            xnew, ynew = np.meshgrid(xnew_coords, ynew_coords)
-        elif len(xnew_coords.shape) == 2 and len(ynew_coords.shape) == 2:
-            assert xnew_coords.shape == ynew_coords.shape, 'If new x and y inputs are a grid, must be same shapes'
-            xnew, ynew = xnew_coords, ynew_coords
-    elif to_frame == 'sci':
-        xnew = xarr / osamp + xnew_cen
-        ynew = yarr / osamp + ynew_cen
+    if to_frame == 'sci':
+        xnew = xarr / osamp + xcen_sci
+        ynew = yarr / osamp + ycen_sci
     else:
-        # Get 'idl' coords
-        xidl = xarr * pixelscale + xidl_cen
-        yidl = yarr * pixelscale + yidl_cen
-
-        xv, yv = aper.convert(xidl, yidl, 'idl', to_frame)
-        xmin, xmax = (xv.min(), xv.max())
-        ymin, ymax = (yv.min(), yv.max())
-
-        # Range xnew from 0 to 1
-        xnew = xarr - xarr.min()
-        xnew /= xnew.max()
-        # Set to xmin to xmax
-        xnew = xnew * (xmax - xmin) + xmin
-        # Make sure center value is xnew_cen
-        xnew += xnew_cen - np.median(xnew)
-
-        # Range ynew from 0 to 1
-        ynew = yarr - yarr.min()
-        ynew /= ynew.max()
-        # Set to ymin to ymax
-        ynew = ynew * (ymax - ymin) + ymin
-        # Make sure center value is xnew_cen
-        ynew += ynew_cen - np.median(ynew)
+        raise NotImplementedError('Only transforms to SCI frame are now supported for distortions.')
 
     # Convert requested coordinates to 'idl' coordinates
     xnew_idl, ynew_idl = aper.convert(xnew, ynew, to_frame, 'idl')
 
     # ###############################################
     # Interpolate using Regular Grid Interpolator
-    xvals = xlin * pixelscale + xidl_cen
-    yvals = ylin * pixelscale + yidl_cen
+    # First we compute the coords in Ideal frame for the input PSF sim on a regular grid
+    xvals = xlin_pix * pixelscale + xcen_idl
+    yvals = ylin_pix * pixelscale + ycen_idl
     func = RegularGridInterpolator(
         (yvals, xvals), hdu_list[ext].data, method='linear', bounds_error=False, fill_value=fill_value
     )
 
     # Create an array of (yidl, xidl) values to interpolate onto
     pts = np.array([ynew_idl.flatten(), xnew_idl.flatten()]).transpose()
+    # And then we interpolate from the input sampling onto the desired output sampling
     psf_new = func(pts).reshape(xnew.shape)
 
     if return_coords:
-        return (psf_new, xnew, ynew)
+        return (psf_new, xnew_idl, ynew_idl)
     else:
         return psf_new
 

--- a/stpsf/tests/test_distortion.py
+++ b/stpsf/tests/test_distortion.py
@@ -159,3 +159,85 @@ def test_distortion_with_custom_pixscale():
 
     assert np.isclose(psf[0].data.sum(), psf[3].data.sum(), rtol=0.001)
     assert np.isclose(psf[1].data.sum(), psf[3].data.sum(), rtol=0.001)
+
+
+# @pytest.mark.skip()
+def test_distortion_linear_anisotropy():
+    """
+    Test that distort_image is correctly reproducing the expected anisotropy in pixel scale between the x and y axes
+
+    To do this, we generate a 2D gaussian of known "ideal" dimensions and check that the correct FWHMs are recovered after distortion is applied.
+
+    See https://github.com/spacetelescope/stpsf/issues/148
+    """
+    from copy import deepcopy
+    from scipy.interpolate import interp1d
+
+    def gaussian_2d(X, Y, mu, A=1.0, sigma=1.0):
+        x0, y0 = mu
+        r2 = (X - x0) ** 2 + (Y - y0) ** 2
+        return A * np.exp(-0.5 * r2 / sigma ** 2)
+
+    def measure_2d_fwhms(image, mu):
+        xsli = image[mu[1], :]
+        ysli = image[:, mu[0]]
+
+        xyv = np.arange(len(xsli))
+
+        x2 = interp1d(xsli[mu[0]:], xyv[mu[0]:])(0.5)
+        x1 = interp1d(xsli[:mu[0]], xyv[:mu[0]])(0.5)
+        xfwhm = x2 - x1
+
+        y2 = interp1d(ysli[mu[1]:], xyv[mu[1]:])(0.5)
+        y1 = interp1d(ysli[:mu[1]], xyv[:mu[1]])(0.5)
+        yfwhm = y2 - y1
+
+        return xfwhm, yfwhm
+
+    nrc = stpsf_core.NIRCam()
+    nrc.filter = 'F444W'
+    nrc.pupil_mask = 'MASKRND'
+    nrc.image_mask = 'MASK335R'
+    nrc.aperturename = 'NRCA5_MASK335R'
+    nrc.set_position_from_aperture_name(nrc.aperturename)
+
+    hdul = nrc.calc_psf(add_distortion=False, monochromatic=4.4e-6,
+                        fov_pixels=120)  # We're primarily running this to get the right header info
+
+    ext = 0
+
+    # Generate a broad 2D gaussian where X/Y scale can be measured more robustly
+    fwhm = 100 * hdul[ext].header['OVERSAMP']
+    sigma = fwhm / np.sqrt(8. * np.log(2.))
+    mu = np.round(((np.array(hdul[ext].data.shape)[::-1]) - 1) / 2.).astype(
+        int)  # Center on nearest pixel to geometric array center
+    Y, X = np.indices(hdul[ext].data.shape, dtype=np.float32)
+    G = gaussian_2d(X, Y, mu, sigma=sigma)
+
+    # Replace PSF model image in the PSF HDUList with the gaussian
+    hdul[ext].data = G
+
+    # Create simplified SIAF aperture to be sure only anisotropy between X and Y scales are relevant.
+    aper = deepcopy(nrc.siaf[nrc.aperturename])
+    for key in aper.__dict__:
+        if key.startswith('Idl2Sci') and aper.__dict__[key] is not None:
+            keyinv = key.replace('Idl2Sci', 'Sci2Idl')
+            if key not in ['Idl2SciX10', 'Idl2SciY11']:  # Zero all coeffs besides X10 and Y11
+                aper.__dict__[key] = aper.__dict__[keyinv] = 0.
+            else:  # Otherwise, ensure reversible transform
+                aper.__dict__[keyinv] = 1. / aper.__dict__[key]
+
+    G_distorted = distortion.distort_image(hdul, ext=ext, to_frame='sci', fill_value=0, aper=aper)
+
+    xfwhm, yfwhm = measure_2d_fwhms(G_distorted, mu)
+
+    xfwhm_expected = fwhm * nrc.pixelscale / aper.XSciScale
+    yfwhm_expected = fwhm * nrc.pixelscale / aper.YSciScale
+
+    assert pytest.approx(xfwhm, rel=1e-5) == xfwhm_expected, (
+        'Distorted image does not have the expected X-axis pixel scale'
+    )
+
+    assert pytest.approx(yfwhm, rel=1e-5) == yfwhm_expected, (
+        'Distorted image does not have the expected Y-axis pixel scale'
+    )

--- a/stpsf/tests/test_distortion.py
+++ b/stpsf/tests/test_distortion.py
@@ -239,7 +239,7 @@ def test_distortion_linear_anisotropy():
     )
 
 
-def test_distortion_pixel_coords_precisely_match_siaf(plot=True):
+def test_distortion_pixel_coords_precisely_match_siaf(plot=False):
     """Test that the distortion code can interpolate + resample pixels onto a grid
     that precisely matches the actual pixel Ideal frame coordinates as specified in SIAF.
 
@@ -287,10 +287,6 @@ def test_distortion_pixel_coords_precisely_match_siaf(plot=True):
         cen = (aper_npix-1)/2+1
         regular_ideal_grid_x = (x_aper_sci - aper.XSciRef) * nrc.pixelscale
         regular_ideal_grid_y = (y_aper_sci - aper.YSciRef) * nrc.pixelscale
-        # Verify: is this regular grid indeed a straight line in x? and in y?
-        assert np.allclose(regular_ideal_grid_x[:, 0], regular_ideal_grid_x[0, 0])
-        assert np.allclose(regular_ideal_grid_y[0], regular_ideal_grid_y[0, 0])
-
 
         fig, ax = plt.subplots(figsize=(12,12))
         nevery = 10
@@ -300,7 +296,6 @@ def test_distortion_pixel_coords_precisely_match_siaf(plot=True):
                    marker='+', label='x/y new grid used in distort_image')
         ax.scatter(x_aper_idl[::nevery, ::nevery], y_aper_idl[::nevery, ::nevery],
                   marker='+', label='aperture pixel Ideal coords from SIAF', s=100, zorder=-10)
-
 
         cornerx, cornery = aper.corners('idl')   # Note, corners are the **outer** corners of the aperture,
                                                  # offset by half a pixel outwards relative to the pixel centers

--- a/stpsf/tests/test_distortion.py
+++ b/stpsf/tests/test_distortion.py
@@ -6,7 +6,6 @@ from .. import distortion
 from .. import stpsf_core
 
 
-# @pytest.mark.skip()
 def test_apply_distortion_skew():
     """
     Test the PSF axis is skewed appropriately by the apply_distortion function.
@@ -54,7 +53,6 @@ def test_apply_distortion_skew():
         assert top_of_left > top_of_right, 'FGS PSF does not have expected skew after distortion application'
 
 
-# @pytest.mark.skip()
 def test_apply_distortion_pixel_scale():
     """
     Test the pixel scale is changed by the apply_distortion function.
@@ -130,7 +128,6 @@ def test_apply_distortion_pixel_scale():
     )
 
 
-# @pytest.mark.skip()
 def test_apply_rotation_error():
     """Test that the apply_rotation function raises an error for NIRSpec and MIRI PSFs"""
 
@@ -161,7 +158,6 @@ def test_distortion_with_custom_pixscale():
     assert np.isclose(psf[1].data.sum(), psf[3].data.sum(), rtol=0.001)
 
 
-# @pytest.mark.skip()
 def test_distortion_linear_anisotropy():
     """
     Test that distort_image is correctly reproducing the expected anisotropy in pixel scale between the x and y axes
@@ -241,3 +237,81 @@ def test_distortion_linear_anisotropy():
     assert pytest.approx(yfwhm, rel=1e-5) == yfwhm_expected, (
         'Distorted image does not have the expected Y-axis pixel scale'
     )
+
+
+def test_distortion_pixel_coords_precisely_match_siaf(plot=True):
+    """Test that the distortion code can interpolate + resample pixels onto a grid
+    that precisely matches the actual pixel Ideal frame coordinates as specified in SIAF.
+
+    This tests proper handling of various aspects of the SIAF usage and pixel coordinate setup
+
+    See https://github.com/spacetelescope/stpsf/issues/148
+    """
+
+    # Setup a sim instance on a subarray
+    nrc = stpsf_core.NIRCam()
+    nrc.filter = 'F444W'
+    nrc.aperturename = 'NRCA5_MASK335R'
+    aper = nrc._detector_geom_info.aperture
+    aper_npix = aper.XSciSize
+    nrc.detector_position = (aper_npix/2, aper_npix/2)  # enforce exact centering for this test, even if the actual reference location is elsewhere in the aperture
+
+    # Compute a PSF, without distortion for now
+    psf = nrc.calc_psf(fov_pixels = aper_npix, oversample=1, add_distortion=False, monochromatic=4e-6)
+
+    ext = 1  # DET_SAMP
+    fill_value = 0
+
+    ### Compute distortion, including inference of pixel coordinates in Science frame
+    psf_dist, xnew_idl, ynew_idl = distortion.distort_image(psf, ext, to_frame='sci', fill_value=fill_value, aper=aper, return_coords=True)
+
+    # Get pixel indices in SIAF Science frame
+    # Recall that SIAF pixel indices are 1-based. This is off by 1 from 0-based Python array indices.
+    # as per Colin Cox in JWST-STScI-001550
+    #  "All pixel counting for JWST starts with (1,1) being the central point within the first pixel."
+    y_aper_sci, x_aper_sci = np.indices((aper_npix, aper_npix))
+    x_aper_sci += 1
+    y_aper_sci += 1
+
+    # Now convert those to Ideal frame
+    x_aper_idl, y_aper_idl = aper.convert(x_aper_sci, y_aper_sci, 'sci', 'idl')
+
+    # Check the coords used in distort_image do match the ones defined in the SIAF
+    assert np.allclose(xnew_idl, x_aper_idl), "X coordinates used in distort_image ought to precisely match SIAF for this setup."
+    assert np.allclose(ynew_idl, y_aper_idl), "Y coordinates used in distort_image ought to precisely match SIAF for this setup."
+
+    if plot:
+        import matplotlib, matplotlib.pyplot as plt
+
+        #--- Compute regular grid of pixels relative to the SciRef location
+        cen = (aper_npix-1)/2+1
+        regular_ideal_grid_x = (x_aper_sci - aper.XSciRef) * nrc.pixelscale
+        regular_ideal_grid_y = (y_aper_sci - aper.YSciRef) * nrc.pixelscale
+        # Verify: is this regular grid indeed a straight line in x? and in y?
+        assert np.allclose(regular_ideal_grid_x[:, 0], regular_ideal_grid_x[0, 0])
+        assert np.allclose(regular_ideal_grid_y[0], regular_ideal_grid_y[0, 0])
+
+
+        fig, ax = plt.subplots(figsize=(12,12))
+        nevery = 10
+        ax.scatter(regular_ideal_grid_x[::nevery, ::nevery], regular_ideal_grid_y[::nevery, ::nevery],
+                   marker='+', label='Regular grid at uniform pixelscale')
+        ax.scatter(xnew_idl[::nevery, ::nevery], ynew_idl[::nevery, ::nevery],
+                   marker='+', label='x/y new grid used in distort_image')
+        ax.scatter(x_aper_idl[::nevery, ::nevery], y_aper_idl[::nevery, ::nevery],
+                  marker='+', label='aperture pixel Ideal coords from SIAF', s=100, zorder=-10)
+
+
+        cornerx, cornery = aper.corners('idl')   # Note, corners are the **outer** corners of the aperture,
+                                                 # offset by half a pixel outwards relative to the pixel centers
+
+        ax.plot(cornerx[[0,1,2,3,0]], cornery[[0,1,2,3,0]],  # use extra indices to close the square
+                color='black',
+                label='Aperture Border')
+
+        ax.set_xlim(5, 11)
+        ax.set_ylim(-11.5, -5.5)
+
+        ax.legend(framealpha=1.0, loc='upper right')
+        ax.set_title(f"Pixel sampling locations in the Ideal frame for {aper.AperName}\nShowing every {nevery}th pixel per axis, and zoomed in on a corner",
+                    )


### PR DESCRIPTION
Fixes and improvements to the distortion code

- [x] Implement @kdlawson's suggested fix for #148 
- [x] Misc cleanup and clarification to `distort_image`. Remove unused parameters and code paths. Rename some variables to clearly indicate which are Ideal vs Science coordinate frames. Add more comments. 
- [x] Add Kellen's new test
- [x] Add Marshall's new test