### PR TITLE
Set Roman pupil radius correctly, even if pupil files have zero padding

### DIFF
--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -373,6 +373,8 @@ JWST_SEGMENT_RADIUS = 1.517 / 2
 JWST_CIRCUMSCRIBED_DIAMETER = 6.603464  # meters. Outer corners of B segments
 JWST_INSCRIBED_DIAMETER = 5.47334  # meters. Middle corners of C segments
 
+ROMAN_PUPIL_DIAMETER = 2.36312  # meters
+
 JWST_TYPICAL_LOS_JITTER_PER_AXIS = 0.0008  # milliarcseconds jitter, 1 sigma per axis. = approx 1 mas rms radial, typically
 
 ROMAN_TYPICAL_LOS_JITTER_PER_AXIS = 0.0060  # milliarcseconds jitter, 1 sigma per axis. See https://github.com/spacetelescope/stpsf/issues/111

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -225,7 +225,7 @@ def _load_wfi_detector_aberrations(filename):
         single_detector_info = zernike_table[zernike_table['sca'] == number]
         field_points = set(single_detector_info['field_point'])
         detector = FieldDependentAberration(
-            4096, 4096, radius=RomanInstrument.PUPIL_RADIUS,
+            4096, 4096, radius=constants.ROMAN_PUPIL_DIAMETER/2,
             name=f"Field Dependent Aberration (WFI{number:02d})"
         )
         for field_id in field_points:
@@ -285,7 +285,6 @@ class _RomanInstrumentOptionsDict(dict):
 
 @utils.combine_docstrings
 class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
-    PUPIL_RADIUS = 2.4 / 2.0
     """
     RomanInstrument contains data and functionality common to Roman
     instruments, such as setting the pupil shape
@@ -294,6 +293,9 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.pupil_radius = constants.ROMAN_PUPIL_DIAMETER / 2  # override default value set in super(), based on FITS file size
+                                                                # which may not be correct since Roman pupil files have some padding
 
         self.siaf = stpsf_core.get_siaf_with_caching('roman')
         self._aperturename = None

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -294,8 +294,7 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.pupil_radius = constants.ROMAN_PUPIL_DIAMETER / 2  # override default value set in super(), based on FITS file size
-                                                                # which may not be correct since Roman pupil files have some padding
+        self.pupil_radius = constants.ROMAN_PUPIL_DIAMETER / 2 * u.meter
 
         self.siaf = stpsf_core.get_siaf_with_caching('roman')
         self._aperturename = None

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -203,7 +203,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         fits.HDUList object corresponding to such a file. If the file contains a
         datacube, you may set this to a tuple (filename, slice) to select a
         given slice, or else the first slice will be used."""
-        self.pupil_radius = None  # Set when loading FITS file in get_optical_system
+        self.pupil_radius = None  # Set in subclass for JWST or Roman
 
         self.options = {}  # dict for storing other arbitrary options.
 
@@ -446,8 +446,6 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         self._extra_keywords['TEL_WFE'] = (float(pupil_rms_wfe_nm), '[nm] Telescope pupil RMS wavefront error')
         if hasattr(pupil_optic, 'header_keywords'):
             self._extra_keywords.update(pupil_optic.header_keywords())
-
-        self.pupil_radius = pupil_optic.pupil_diam / 2.0
 
         # add coord transform from entrance pupil to exit pupil
         optsys.add_inversion(axis='y', name='OTE exit pupil', hide=True)
@@ -826,6 +824,8 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         self.pupil = os.path.abspath(os.path.join(self._STPSF_basepath, 'jwst_pupil_RevW_npix1024.fits.gz'))
         'Filename *or* fits.HDUList for JWST pupil mask. Usually there is no need to change this.'
+
+        self.pupil_radius = constants.JWST_CIRCUMSCRIBED_DIAMETER / 2 * units.meter
 
         self._aperturename = None
         self._detector = None


### PR DESCRIPTION
This should fix #151 reported by @bergkoet.

Currently, we are setting both a `RomanTelescope.PUPIL_RADIUS` class attribute (~correctly) and a `self.pupil_radius` instance attribute (incorrectly), which is both not working and also more complex than is necessary. This PR simplifies to just setting a `self.pupil_radius` value, correctly. Conveniently the `PUPIL_RADIUS` one was only used in one single place in the code so this is not a complex edit.

I moved the numeric value definition to `constants.py` which is a better place for it anyhow.  