### PR TITLE
Fix broken API links in Roman notebook

### DIFF
--- a/notebooks/STPSF-Roman_Tutorial.ipynb
+++ b/notebooks/STPSF-Roman_Tutorial.ipynb
@@ -255,7 +255,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "STPSF also includes functions for measuring EE, profiles, and centroids (described in the [STPSF documentation](http://pythonhosted.org/stpsf/api_reference.html#functions) and the [POPPY documentation](http://pythonhosted.org/poppy/api.html#functions)). Below we measure the radial profile and encircled energy curve for the monochromatic PSF. (Note that the FWHM is also computed and labeled on the radial profile plot.)"
+    "STPSF also includes functions for measuring EE, profiles, and centroids (described in the [STPSF documentation](https://stpsf.readthedocs.io/en/latest/api_reference.html#functions) and the [POPPY documentation](https://poppy-optics.readthedocs.io/en/latest/api.html#functions)). Below we measure the radial profile and encircled energy curve for the monochromatic PSF. (Note that the FWHM is also computed and labeled on the radial profile plot.)"
    ]
   },
   {


### PR DESCRIPTION
Besides these, I didn't find any other occurrences of the outdated "pythonhosted" URLs in the `docs` directory.