### PR TITLE
Adapt Roman code to new required data files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,10 @@ jobs:
       - retrieve_cache
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@4193751d511425d4edc1d5657c24b2128d49b017 # v2.6.4
     with:
+      setenv: |
+        STPSF_PATH: ${{ needs.retrieve_cache.outputs.cache_path }}/stpsf-data/
+      cache-path: ${{ needs.retrieve_cache.outputs.cache_path }}
+      cache-key: ${{ needs.retrieve_cache.outputs.cache_key }}
       envs: |
         - name: Check for Sphinx doc build errors
           linux: py312-docbuild

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,8 +105,6 @@ jobs:
         - name: run tests with poppy dev (latest support Python, ubuntu-latest)
           linux: py3-poppydev-xdist
           python-version: ${{ needs.supported-pythons.outputs.latest }}
-      fill: true
-      fill_platforms: linux
-      fill_factors: xdist
+        - linux: py3*-xdist
       artifact-path: |
         results.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,16 +22,18 @@ env:
   PYTHON_VERSIONS: 3.9 3.10 3.11 3.12 3.13 3.14
 
 jobs:
+  retrieve_cache:
+    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@ee1ced313cc7277f07226f03e64d038f3929d7a3 # setup retrieve_cache with development or latest_release
+    with:
+      dataset_type: development   # or latest_release
   check:
+    needs:
+      - retrieve_cache
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@4193751d511425d4edc1d5657c24b2128d49b017 # v2.6.4
     with:
       envs: |
         - name: Check for Sphinx doc build errors
           linux: py312-docbuild
-  retrieve_cache:
-    uses: spacetelescope/stpsf/.github/workflows/retrieve_cache.yml@ee1ced313cc7277f07226f03e64d038f3929d7a3 # setup retrieve_cache with development or latest_release
-    with:
-      dataset_type: development   # or latest_release
   supported-pythons:
     runs-on: ubuntu-latest
     steps:
@@ -65,7 +67,7 @@ jobs:
     outputs:
       python-version-json: ${{ steps.versions.outputs.json }}
       oldest: ${{ steps.versions.outputs.oldest }}
-      latest: ${{ steps.versions.outputs.latest }} 
+      latest: ${{ steps.versions.outputs.latest }}
   test:
     needs:
       - retrieve_cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
   check:
     needs:
       - retrieve_cache
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@4193751d511425d4edc1d5657c24b2128d49b017 # v2.6.4
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@22ddf09dfabb443adddfb9f861b7d41a787d6b1a # v3.0.3
     with:
       setenv: |
         STPSF_PATH: ${{ needs.retrieve_cache.outputs.cache_path }}/stpsf-data/
@@ -76,7 +76,7 @@ jobs:
     needs:
       - retrieve_cache
       - supported-pythons
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@4193751d511425d4edc1d5657c24b2128d49b017 # v2.6.4
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@22ddf09dfabb443adddfb9f861b7d41a787d6b1a # v3.0.3
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -92,7 +92,7 @@ jobs:
           linux: py3-cov-xdist
           python-version: ${{ needs.supported-pythons.outputs.latest }}
           pytest-results-summary: true
-          coverage: codecov
+          coverage: github
         - name: run tests (latest supported Python, ubuntu-latest)
           linux: py3-xdist
           python-version: ${{ needs.supported-pythons.outputs.latest }}

--- a/stpsf/__init__.py
+++ b/stpsf/__init__.py
@@ -40,7 +40,7 @@ if sys.version_info < tuple(
 # required. If changes to the code and data mean STPSF won't work
 # properly with an old data package, increment this version number.
 # (It's checked against $STPSF_DATA/version.txt)
-DATA_VERSION_MIN = (2, 1, 0)
+DATA_VERSION_MIN = (2, 3, 0)
 
 
 class Conf(_config.ConfigNamespace):

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -222,28 +222,27 @@ class FieldDependentAberration(poppy.ZernikeWFE):
             field_position = tuple(self.field_position)
             coefficients = griddata(np.asarray(field_points), np.asarray(aberration_terms), field_position, method='linear')
             if np.any(np.isnan(coefficients)):
-                # FIND TWO CLOSEST INPUT GRID POINTS:
-                dist = []
-                corners = field_points[1:]  # use only the corner points
-                for i, ip in enumerate(corners):
-                    dist.append(np.sqrt(((ip[0] - field_position[0]) ** 2) + ((ip[1] - field_position[1]) ** 2)))
+                # Find two closest input grid points
+                # [decomposed hypot args are (xdiffs, ydiffs)]
+                dist = np.hypot(*(np.asarray(field_points)
+                                  - np.asarray(field_position)).T)
                 min_dist_indx = np.argsort(dist)[:2]  # keep two closest points
-                # DEFINE LINE B/W TWO POINTS, FIND ORTHOGONAL LINE AT POINT OF INTEREST,
-                # AND FIND INTERSECTION OF THESE TWO LINES.
-                x1, y1 = corners[min_dist_indx[0]]
-                x2, y2 = corners[min_dist_indx[1]]
+                # Define line between two points, then find orthogonal line at
+                # point of interest and intersection of these two lines
+                x1, y1 = field_points[min_dist_indx[0]]
+                x2, y2 = field_points[min_dist_indx[1]]
                 dx = x2 - x1
                 dy = y2 - y1
                 a = (dy * (field_position[1] - y1) + dx * (field_position[0] - x1)) / (dx * dx + dy * dy)
                 closest_interp_point = (x1 + a * dx, y1 + a * dy)
-                # INTERPOLATE ABERRATIONS TO CLOSEST INTERPOLATED POINT:
+                # Interpolate aberrations to closest interpolated point
                 coefficients = griddata(
                     np.asarray(field_points), np.asarray(aberration_terms), closest_interp_point, method='linear'
                 )
-                # IF CLOSEST INTERPOLATED POINT IS STILL OUTSIDE THE INPUT GRID,
-                # THEN USE NEAREST GRID POINT INSTEAD:
+                # If closest interpolatd point is still outside the input grid,
+                # use nearest grid point instead
                 if np.any(np.isnan(coefficients)):
-                    coefficients = aberration_terms[min_dist_indx[0] + 1]
+                    coefficients = aberration_terms[min_dist_indx[0]]
                     _log.warn(
                         'Attempted to get aberrations at field point {} which is outside the range '
                         'of the reference data; approximating to nearest input grid point'.format(field_position)

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -21,6 +21,11 @@ from scipy.interpolate import griddata
 
 from . import distortion, utils, stpsf_core, detectors, constants
 
+# Monkey patch: double the cache size over the default maxsize=128
+# to prevent slowdowns from increased number of Zernike coefficients
+from functools import lru_cache
+poppy.zernike.cached_zernike1 = lru_cache(maxsize=256)(poppy.zernike.cached_zernike1.__wrapped__)
+
 _log = logging.getLogger('stpsf')
 
 GRISM_FILTERS = ('GRISM0', 'GRISM1')

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -4,8 +4,7 @@ Roman Instruments
 =================
 
 WARNING: This model has not yet been validated against other PSF
-         simulations, and uses several approximations (e.g. for
-         mirror polishing errors, which are taken from HST).
+         simulations and uses several approximations.
 """
 
 import logging
@@ -28,15 +27,67 @@ GRISM_FILTERS = ('GRISM0', 'GRISM1')
 PRISM_FILTERS = ('PRISM',)
 
 
+def _wfi_sci_xy_to_fp(x, y):
+    """
+    Convert from (x, y) in pixel coordinates to the field point numbering used
+    for WFI Zernikes and pupil masks.
+
+    Inverse of _wfi_fp_to_sci_xy().
+
+    Parameters
+    ----------
+    x, y : float
+        Pixel coordinates in Science frame. Values expected to be within 0-4096.
+
+    Returns
+    -------
+    fp : int
+        Field point index from 1 to 25.
+    """
+    n = WFI.NPIXELS
+    vertical = np.round(4 * y / n + 1)
+    horizontal = np.round(4 * (n - x) / n)
+    fp = int(horizontal * 5 + vertical)
+    return fp
+
+
+def _wfi_fp_to_sci_xy(fp):
+    """
+    Convert from field point number to Science frame X, Y pixel coordinates.
+
+    Inverse of _wfi_sci_xy_to_fp().
+
+    Parameters
+    ----------
+    fp : int
+        Field point index from 1 to 25.
+
+    Returns
+    -------
+    (x, y) : tuple
+        Pixel coordinates in Science frame. Values expected to be within 0-4096.
+    """
+    n = WFI.NPIXELS
+    y = int(np.mod(fp - 1, 5) * n // 4)
+    x = int(4 - (fp - 1) // 5) * n // 4
+    return (x, y)
+
+
 class WavelengthDependenceInterpolator(object):
-    """WavelengthDependenceInterpolator can be configured with
+    """
+    WavelengthDependenceInterpolator can be configured with
     `n_zernikes` worth of Zernike coefficients at up to `n_wavelengths`
     wavelengths, and will let you `get_aberration_terms` for any
     wavelength in range interpolated linearly between measured/known
-    points
+    points.
+
+    For an imaging filter in STPSF's default reference WFI data,
+    n_wavelengths=3 and n_zernikes=210. For a grism or prism filter,
+    n_wavelengths=16 and n_zernikes=45. See the docstring for
+    `build_detector_from_table()` in this file for more information.
     """
 
-    def __init__(self, n_wavelengths=16, n_zernikes=45):
+    def __init__(self, n_wavelengths, n_zernikes):
         self._n_wavelengths = n_wavelengths
         self._n_zernikes = n_zernikes
         self._aberration_terms = np.zeros((n_wavelengths, n_zernikes), dtype=np.float64)
@@ -55,14 +106,12 @@ class WavelengthDependenceInterpolator(object):
         else:
             # can't add more wavelengths without allocating new _aberration_terms array
             raise ValueError(
-                'Already have information at {} wavelengths ' '(pass larger n_wavelengths to __init__?)'.format(
-                    self._n_wavelengths
-                )
-            )
+                f"Already have information at {self._n_wavelengths} "
+                "wavelengths (pass larger n_wavelengths to __init__?)")
         if len(zernike_array) != self._n_zernikes:
             raise ValueError(
-                'Expected {} aberration terms (pass different ' 'n_zernikes to __init__?)'.format(self._n_zernikes)
-            )
+                f"Expected {self._n_zernikes} aberration terms (pass different "
+                "n_zernikes to __init__?)")
         self._aberration_terms[aberration_row_idx] = zernike_array
 
     def get_aberration_terms(self, wavelength):
@@ -92,23 +141,23 @@ class WavelengthDependenceInterpolator(object):
 
 
 class FieldDependentAberration(poppy.ZernikeWFE):
-    """FieldDependentAberration incorporates aberrations that
+    """
+    FieldDependentAberration incorporates aberrations that
     are interpolated in wavelength, x, and y pixel positions by
     computing the Zernike coefficients for a particular wavelength
     and position.
-    """
 
-    """By default, `get_aberration_terms` will zero out Z1, Z2, and Z3
+    By default, `get_aberration_terms` will zero out Z1, Z2, and Z3
     (piston, tip, and tilt) as they are not meaningful for telescope
     PSF calculations (the former is irrelevant; the latter two would
     be handled by a distortion solution). Change
-    `_omit_piston_tip_tilt` to False to include the Z1-3 terms."""
+    `_omit_piston_tip_tilt` to False to include the Z1-3 terms.
+    """
     _omit_piston_tip_tilt = True
     _field_position = None
 
-    def __init__(
-        self, pixel_width, pixel_height, name='Field-dependent Aberration', radius=1.0, oversample=1, interp_order=3
-    ):
+    def __init__(self, pixel_width, pixel_height, name='Field-dependent Aberration',
+                 radius=1.0, oversample=1, interp_order=3):
         self.pixel_width, self.pixel_height = pixel_width, pixel_height
         self.field_position = pixel_width // 2, pixel_height // 2
         self._wavelength_interpolators = {}
@@ -124,7 +173,7 @@ class FieldDependentAberration(poppy.ZernikeWFE):
             wavelength = wave
         else:
             wavelength = wave.wavelength
-        self.coefficients = wavelength * self.get_aberration_terms(wavelength)
+        self.coefficients = self.get_aberration_terms(wavelength) * u.meter
         return super().get_opd(wave)
 
     @property
@@ -216,37 +265,54 @@ def _load_wfi_detector_aberrations(filename):
     zernike_table = ascii.read(filename, encoding='utf-8-sig')
     detectors_dict = {}
 
+    det_col = 'sca'
+    fp_col = 'fov'
+    wave_col = 'wave'
+    det_pos_x_col = 'SCI_X'  # already in pixels
+    det_pos_y_col = 'SCI_Y'  # already in pixels
+    calc_pix = False
+    conv_wv_to_m = 1e-9  # nm to m
+    # (Zernike units set separately in FieldDependentAberration.get_opd())
+
     def build_detector_from_table(number, zernike_table):
-        """Build a FieldDependentAberration optic for a detector using
-        number of Zernike terms found per row (Z1-Z45 by default) for
-        specified wavelengths and field points"""
+        """
+        Build a FieldDependentAberration optic for a detector using number of
+        Zernike terms found per row for specified wavelength and field points.
+
+        In STPSF's default reference WFI data, imaging filters contain
+        aberration data at the low, middle, and high wavelengths of their
+        bandpasses. There are 16 unique wavelengths with recorded aberration
+        data across the WFI's imaging filters. The prism, grism0, and grism1
+        filters each contain aberration data for all 16 such wavelengths.
+
+        Each imaging filter contains 25 field points per detector and Zernike
+        coefficients up to Z210 for each detector/field point/intra-filter
+        wavelength combination. The grism/prism filters contain 5 field points
+        per detector and Zernike coefficients up to Z45 for each
+        detector/field point/intra-filter wavelength combination.
+        """
         n_zernikes = len([c for c in zernike_table.columns
                           if re.match(r'Z\d+', c)])
-        single_detector_info = zernike_table[zernike_table['sca'] == number]
-        field_points = set(single_detector_info['field_point'])
+        single_detector_info = zernike_table[zernike_table[det_col] == number]
+        field_points = set(single_detector_info[fp_col])
         detector = FieldDependentAberration(
-            4096, 4096, radius=constants.ROMAN_PUPIL_DIAMETER/2,
+            WFI.NPIXELS, WFI.NPIXELS, radius=constants.ROMAN_PUPIL_DIAMETER/2,
             name=f"Field Dependent Aberration (WFI{number:02d})"
         )
         for field_id in field_points:
-            field_point_rows = single_detector_info[single_detector_info['field_point'] == field_id]
-            local_x, local_y = field_point_rows[0]['local_x'], field_point_rows[0]['local_y']
+            field_point_rows = single_detector_info[single_detector_info[fp_col] == field_id]
+            local_x, local_y = (field_point_rows[0][det_pos_x_col],
+                                field_point_rows[0][det_pos_y_col])
             interpolator = build_wavelength_dependence(field_point_rows,
                                                        n_zernikes)
 
-            midpoint_pixel = 4096 / 2
-            # (local_x in mm / 10 um pixel size) -> * 1e2
-            # local_x and _y range from -20.44 to +20.44, so adding to the midpoint pixel
-            # makes sense to place (-20.44, -20.44) at (4, 4)
-            pixx, pixy = (round(midpoint_pixel - local_x * 1e2), round(midpoint_pixel + local_y * 1e2))
-
-            detector.add_field_point(pixx, pixy, interpolator)
+            detector.add_field_point(local_x, local_y, interpolator)
         return detector
 
     def build_wavelength_dependence(rows, n_zernikes):
         """Build an interpolator object that interpolates `n_zernikes` Zernike
         terms in wavelength space"""
-        wavelengths = set(rows['wavelength'])
+        wavelengths = set(rows[wave_col])
         interpolator = WavelengthDependenceInterpolator(
             n_wavelengths=len(wavelengths),
             n_zernikes=n_zernikes
@@ -254,7 +320,7 @@ def _load_wfi_detector_aberrations(filename):
         for row in rows:
             z = np.array([row['Z{}'.format(idx + 1)]
                           for idx in range(n_zernikes)])
-            interpolator.set_aberration_terms(row['wavelength'] * 1e-6, z)
+            interpolator.set_aberration_terms(row[wave_col] * conv_wv_to_m, z)
 
         return interpolator
 
@@ -377,18 +443,18 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
 
         return psf
 
-    # slightly different versions of the following two functions
-    # from the parent superclass
-    # in order to interface with the FieldDependentAberration class
+    # slightly different versions of the following two functions from the parent
+    # superclass in order to interface with the FieldDependentAberration class
     @property
     def detector_position(self):
         """The pixel position in (X, Y) on the detector"""
-        return self._detectors[self._detector].field_position
+        return self._detector_position
 
     @detector_position.setter
     def detector_position(self, position):
-        # exact copy of superclass function except we save the
-        # into a different location.
+        """Save new detector pixel position into the each detector's
+        FieldDependentAberration instance. Update index of matching field
+        point's slice in pupil file data cube."""
         try:
             x, y = map(int, position)
         except ValueError:
@@ -400,7 +466,13 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
                 'The maximum allowed detector pixel ' 'coordinate value is {}'.format(self._detector_npixels - 1)
             )
 
-        self._detectors[self._detector].field_position = (int(position[0]), int(position[1]))
+        for det, aber_obj in self._detectors.items():
+            aber_obj.field_position = (int(position[0]), int(position[1]))
+        self._detector_position = position
+
+        self._pupil_datacube_index = _wfi_sci_xy_to_fp(*position) - 1
+        # subtract 1 because field point indices in the GSFC source data are
+        # 1-indexed while the pupil file datacube is 0-indexed
 
     def _get_aberrations(self):
         """Get the OpticalElement that applies the field-dependent
@@ -547,24 +619,22 @@ class WFIPupilController:
         self._datapath = datapath
         self._pupil_basepath = os.path.join(self._datapath, 'pupils')
 
-    def pupil_file_formatter(self, wfi_filter, detector):
+    def pupil_file_formatter(self, pupil_mask, detector):
         """
         Generate proper pupil filename given a filter and a detector.
 
         Parameters
         ----------
-        wfi_filter : string
-            See WFI.filter_list for a list of valid filters.
+        pupil_mask : string
+            See WFI.filter_list for a list of valid filters. Pupil mask names
+            match filter names for all except 'GRISM', which is shared between
+            pupil masks 'GRISM0' and 'GRISM1'.
 
         detector : string
             See WFI.detector_list for a list of valid detectors.
         """
-        if wfi_filter.upper().startswith('F'):
-            return f"RST_WIM_Filter_{wfi_filter}_{detector}.fits.gz"
-        elif wfi_filter.upper().startswith('GRISM'):
-            return f"RST_WSM_Grism_grism_{detector}.fits.gz"
-        elif wfi_filter.upper() == 'PRISM':
-            return f"RST_WSM_Prism_prism_{detector}.fits.gz"
+        return (f"RST_WFI_pupil_{pupil_mask.title()}_"
+                f"{detector}_allfieldpoints.fits.gz")
 
     def update_pupil(self, wfi_filter, detector):
         """
@@ -663,9 +733,9 @@ class WFI(RomanInstrument):
     WFI represents the Roman mission's Wide Field Imager.
 
     WARNING: This model has not yet been validated against other PSF
-             simulations, and uses several approximations (e.g. for
-             mirror polishing errors, which are taken from HST).
+             simulations and uses several approximations.
     """
+    NPIXELS = 4096
 
     def __init__(self):
         # pixel scale is from Roman-AFTA SDT report final version (p. 91)
@@ -691,18 +761,30 @@ class WFI(RomanInstrument):
         self._aberration_files.update({
             fltr: os.path.join(
                 self._datapath,
-                (f"{'WIM' if fltr.startswith('F') else 'WSM'}"
-                 f"_{fltr}_zernikes_cycle10.csv"))
-            for fltr in self.filter_list
-        })
+                'aberrations',
+                # f"{fltr}_25fields_Z210_multiwave.csv"
+                f"{fltr}_25fields_zernike_Z210_multiwavelength.csv"
+                if fltr.startswith('F')
+                else f"{fltr}_5fields_Z45_multiwave.csv")
+            for fltr in self.filter_list})
 
-        # Load and set default detector from aberration file
-        self._detector_npixels = 4096
+        # Load aberration info from ref files
+        self._detector_npixels = self.NPIXELS
         self._load_detector_aberrations(self._aberration_files[self.mode])
-        self.detector = 'WFI01'
 
-        self.opd_list = [os.path.join(self._STPSF_basepath, 'upscaled_HST_OPD.fits')]
-        self.pupilopd = self.opd_list[-1]
+        self._opd_file_dict = {
+            det: os.path.join(
+                self._datapath,
+                'aberrations',
+                # f"{det}_Z210_high_freq_cube.fits"
+                f"SCA{i}_Z210_high_frequency_cube.fits")
+            # for det in self.detector_list})
+            for i, det in enumerate(self.detector_list, 1)}
+        self._pupilopd = self._opd_file_dict['WFI01']
+
+        # Set initial detector and position
+        self.detector = 'WFI01'
+        self.detector_position = (self.NPIXELS // 2, self.NPIXELS // 2)
 
     def _addAdditionalOptics(self, optsys, **kwargs):
         _log.debug('   No optics added for WFI')
@@ -744,7 +826,27 @@ class WFI(RomanInstrument):
         assert self.pupil is not None, 'pupil is None'
         super()._validate_config(**kwargs)
 
+    @property
+    def pupilopd(self):
+        """The file containing high-frequency Zernike information for the
+        current detector. Set by the detector setter."""
+        return self._pupilopd
+
+    @pupilopd.setter
+    def pupilopd(self, value):
+        # Only allow direct set of pupilopd when done by parent class in super()
+        # (i.e., before WFI class has set a detector)
+        if self.detector is None:
+            self._pupilopd = value
+        else:
+            raise ValueError('pupilopd is set automatically on updates to the '
+                             'detector attribute')
+
     def _update_pupil(self, wfi_filter=None, detector=None):
+        """
+        Chooses proper pupil file. Pupil file geometry depends on field position
+        parameterized by detector and field position number within a detector.
+        """
         if detector is None:
             detector = self.detector
         if wfi_filter is None:
@@ -759,8 +861,9 @@ class WFI(RomanInstrument):
         """
         The current WFI detector. See WFI.detector_list for valid values.
 
-        As of Cycle 10, also switches the current filter's throughput file
-        location since these are now detector-based.
+        Also adjusts the current 1) pupil file (since these depend on filter and
+        *detector*), 2) path to throughput files, and 3) OPD file containing
+        contributions from high-frequency Zernike terms above Z210.
         """
         if value.upper().startswith('SCA'):  # backward-compatible name assignment
             value = f"WFI{value[-2:]}"
@@ -768,8 +871,13 @@ class WFI(RomanInstrument):
             raise ValueError('Invalid detector. Valid detector names are: {}'.format(', '.join(self.detector_list)))
 
         self._detector = value.upper()
+
+        # Update pupil and high-frequency OPD file locations (conditional needed
+        # to exclude call to setter by SpaceTelescopeInstrument.__init__()
         if self._detector is not None:
             self._update_pupil(detector=self._detector)
+
+        # Update throughput file directory
         self._update_aperturename()
 
     def _update_aperturename(self):

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -846,8 +846,8 @@ class WFI(RomanInstrument):
         if self.detector is None:
             self._pupilopd = value
         else:
-            raise ValueError('pupilopd is set automatically on updates to the '
-                             'detector attribute')
+            raise ValueError('WFI.pupilopd is set automatically on updates to '
+                             'its detector attribute, not manually.')
 
     def _update_pupil(self, wfi_filter=None, detector=None):
         """

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -329,9 +329,10 @@ def _load_wfi_detector_aberrations(filename):
 
         return interpolator
 
-    detector_ids = set(zernike_table['sca'])
+    detector_ids = set(zernike_table[det_col])
     for detid in detector_ids:
-        detectors_dict['WFI{:02}'.format(detid)] = build_detector_from_table(detid, zernike_table)
+        detid = int(detid) # temp to support g/prism Zernike CSVs
+        detectors_dict[f"WFI{detid:02}"] = build_detector_from_table(detid, zernike_table)
 
     return detectors_dict
 
@@ -770,7 +771,8 @@ class WFI(RomanInstrument):
                 # f"{fltr}_25fields_Z210_multiwave.csv"
                 f"{fltr}_25fields_zernike_Z210_multiwavelength.csv"
                 if fltr.startswith('F')
-                else f"{fltr}_5fields_Z45_multiwave.csv")
+                # else f"{fltr}_5fields_Z45_multiwave.csv")
+                else f"{fltr}_5fields_zernike_Z45_multiwavelength.csv")
             for fltr in self.filter_list})
 
         # Load aberration info from ref files
@@ -782,7 +784,7 @@ class WFI(RomanInstrument):
                 self._datapath,
                 'aberrations',
                 # f"{det}_Z210_high_freq_cube.fits"
-                f"SCA{i}_Z210_high_frequency_cube.fits")
+                f"RST_WFI{i}_Z210_high_frequency_map.fits")
             # for det in self.detector_list})
             for i, det in enumerate(self.detector_list, 1)}
         self._pupilopd = self._opd_file_dict['WFI01']

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -448,8 +448,10 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
             self._extra_keywords.update(pupil_optic.header_keywords())
 
         # add coord transform from entrance pupil to exit pupil
-        # unless ref data are already in exit pupil orientation (like with WFI)
-        if self.name != 'WFI':
+        # (WFI: invert both axes until pupil orientations fixed in source files)
+        if self.name == 'WFI':
+            optsys.add_inversion(axis='both', name='OTE exit pupil', hide=True)
+        else:
             optsys.add_inversion(axis='y', name='OTE exit pupil', hide=True)
 
         # add rotation at this point, if present - needs to be after the

--- a/stpsf/stpsf_core.py
+++ b/stpsf/stpsf_core.py
@@ -448,7 +448,9 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
             self._extra_keywords.update(pupil_optic.header_keywords())
 
         # add coord transform from entrance pupil to exit pupil
-        optsys.add_inversion(axis='y', name='OTE exit pupil', hide=True)
+        # unless ref data are already in exit pupil orientation (like with WFI)
+        if self.name != 'WFI':
+            optsys.add_inversion(axis='y', name='OTE exit pupil', hide=True)
 
         # add rotation at this point, if present - needs to be after the
         # exit pupil inversion.
@@ -589,10 +591,15 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
                 pupil_transmission = self.pupil
             else:
                 raise TypeError('Not sure what to do with a pupil of ' 'that type: {}'.format(type(self.pupil)))
+            # ---- check if we have an index into a datacube; this is used for Roman
+            transmission_index = (self._pupil_datacube_index
+                                  if hasattr(self, '_pupil_datacube_index')
+                                  else None)
             # ---- apply pupil intensity and OPD to the optical model
             pupil_optic = poppy.FITSOpticalElement(
                 name='{} Entrance Pupil'.format(self.telescope),
                 transmission=pupil_transmission,
+                transmission_index=transmission_index,
                 opd=opd_map,
                 planetype=poppy.poppy_core.PlaneType.pupil,
                 # rotation=self._rotation

--- a/stpsf/tests/test_roman.py
+++ b/stpsf/tests/test_roman.py
@@ -290,3 +290,15 @@ def test_WFI_auto_aperturename_and_pixelscale():
 
     aperture = wfi.siaf[wfi.aperturename]
     assert wfi.pixelscale == (aperture.XSciScale + aperture.YSciScale)/2, "Pixel scale should match the SIAF for that aperturename"
+
+
+def test_sci_xy_to_fp():
+    """Test corners match expectations"""
+    corner_data = ( ((0,0), 21),  # lower left
+                    ((0, 4096), 25),  # upper left
+                    ((4096, 0), 1),  # lower right
+                    ((4096, 4096), 5)  # upper right
+                  )
+    for (x, y), fp in corner_data:
+        assert roman._wfi_sci_xy_to_fp(x, y) == fp  # test xy->fp
+        assert roman._wfi_sci_xy_to_fp(*roman._wfi_fp_to_sci_xy(fp)) == fp , f'round trip error for fp {fp}'  # test round trip

--- a/stpsf/tests/test_roman.py
+++ b/stpsf/tests/test_roman.py
@@ -71,7 +71,7 @@ def test_WFI_fwhm():
     """
     wfi = roman.WFI()
 
-    wfi.pupilopd = None
+    wfi._pupilopd = None
     wfi.options['jitter'] = None
 
     wfi.filter = 'F062'
@@ -251,8 +251,8 @@ def test_WFI_limits_interpolation_range():
 
     # Get min and max valid wavelengths from aberration file
     zern = Table.read(wfi._aberration_files[wfi.mode], format='ascii.csv')
-    min_wv = zern['wavelength'][0] * 1e-6  # convert from micron to meter
-    max_wv = zern['wavelength'][-1] * 1e-6
+    min_wv = zern['wave'][0] * 1e-9  # convert from nm to meter
+    max_wv = zern['wave'][-1] * 1e-9
 
     # Test that get_aberration_terms() uses an approximated wavelength when
     # called with an out-of-bounds wavelength.

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ isolated_build = true
 passenv = *
 extras =
     test
-deps = 
+deps =
     pytest-remotedata   # ignore tests that use remote data, e.g. MAST, when running in CI
     poppydev,astropydev: git+https://github.com/spacetelescope/poppy.git#egg=poppy
     pysiafdev,astropydev: git+https://github.com/spacetelescope/pysiaf.git#egg=pysiaf
@@ -25,7 +25,7 @@ uv_resolution =
     !legacy: highest
 commands=
     pytest \
-    cov: --cov-config=pyproject.toml --cov-report=xml --cov=stpsf \ 
+    cov: --cov-config=pyproject.toml --cov-report=xml --cov=stpsf \
     xdist: -n=2 --dist=loadscope \
     {posargs}
 


### PR DESCRIPTION
Cleans up my test branch with code changes to handle the new structure of the required Roman data from GSFC – OPDs, pupils, and expanded Zernike coefficients.

Let's see if changing `DATA_VERSION_MIN` in `stpsf/__init__.py` is enough to enforce the use of the new files as we test this branch. If we merge this branch before the release is ready, we may need to revert this change so others who want to use the `develop` branch but don't have the files can still run STPSF.

I included @mperrin's quick fix to prevent large slowdowns from the number of Zernike coefficients exceeding the `lru_cache`'s default maximum size, but we could still benefit from either aligning the calculation more with the approach taken in STPSF's JWST models (future task) or by making the `R()` function from poppy's `zernike.py` more efficient.