### PR TITLE
Implement IPC for WFI

### DIFF
--- a/stpsf/constants.py
+++ b/stpsf/constants.py
@@ -393,7 +393,6 @@ INSTRUMENT_DETECTOR_CHARGE_DIFFUSION_DEFAULT_PARAMETERS = {
     'MIRI': 0.001,  # Fit by Marshall + Marcio to ePSFs, after adding IPC
     #  0.070 Based on user reports, see issue #674. However, this was before adding IPC effects
     'WFI': 0.033,  # 20250919 Value from Goddard recommendation (stpsf issue #111)
-    'ROMANCORONAGRAPH': 0.0
 }
 # add Interpixel capacitance (IPC) effects. These are the parameters for each detector kernel
 # For NIRCam we  use CV3/Flight convolution kernels from Jarron Leisenring, see detectors.apply_detector_ipc for details

--- a/stpsf/detectors.py
+++ b/stpsf/detectors.py
@@ -134,7 +134,21 @@ def get_detector_ipc_model(inst, header):
             meta['IPCFILE'] = ('Not found', 'IPC model source file')
             stpsf.stpsf_core._log.info(f'NIRISS IPC kernel file {ipc_file} not found.')
 
-    elif inst in ['FGS', 'NIRSPEC', 'WFI']:
+    if inst == 'WFI':
+        stpsf.stpsf_core._log.info(f"Detector IPC: WFI detector {det} added")
+
+        # could query latest from CRDS instead? currently convert latest IPC
+        # ref files from CRDS from separate ASDF files to
+        sca_path = os.path.join(utils.get_stpsf_data_path(), 'WFI',
+                                'ipc_kernel_by_det.fits')
+        kernel = CustomKernel(fits.getdata(sca_path, extname=det))
+
+        meta['IPCINST'] = ('WFI', 'Interpixel capacitance (IPC)')
+        meta['IPCFILE'] = (os.path.basename(sca_path), 'IPC model source file')
+        meta['IPCCRDS'] = (fits.getheader(sca_path, extname=det)['FILENAME'],
+                           'CRDS reference file used for IPC')
+
+    elif inst in ['FGS', 'NIRSPEC']:
         kernel = None  # No IPC models yet implemented for these
         meta['IPCFILE'] = ('Not found', 'IPC model source file')
 
@@ -154,6 +168,8 @@ def apply_detector_ipc(psf_hdulist, extname='DET_DIST'):
 
     For NIRISS the user needs to have the right kernels under $STPSF_PATH/NIRISS/IPC/
     These kernels should be available with stpsf data > Version 1.1.1
+
+    WFI: Convolution kernels from CRDS (roman_wfi_ipc_0003.rmap)
 
     You can turn On/Off IPC effects as an option.
      For example: inst.option['add_ipc'] = False, where inst is the instrument class. Default is True.

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -358,7 +358,7 @@ class _RomanInstrumentOptionsDict(dict):
 class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
     """
     RomanInstrument contains data and functionality common to Roman
-    instruments, such as setting the pupil shape
+    instruments, such as setting the pupil shape.
     """
     telescope = 'Roman'
 
@@ -375,6 +375,9 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
         self.options['add_distortion'] = 'NA'  # distortion can't be toggled
         self.options = _RomanInstrumentOptionsDict(self.options.copy())
 
+        # then, set defaults for options modifiable by users
+        self.options['add_ipc'] = False
+        # charge_diffusion_sigma set in RomanInstrument._calc_psf_format_output
         self.options['jitter'] = 'gaussian'
         self.options['jitter_sigma'] = constants.ROMAN_TYPICAL_LOS_JITTER_PER_AXIS
         # arcsec/axis, see https://github.com/RomanSpaceTelescope/roman-technical-information/tree/main/data/Observatory/MissionandObservatoryTechnicalOverview#telescope-parameters
@@ -514,6 +517,7 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
         Modifies the 'result' HDUList object.
 
         """
+        _log.info('Adding PSF detector effects')
         # Set up new extensions for detector charge transfer model
         n_exts = len(result)
         for ext in np.arange(n_exts):
@@ -522,9 +526,10 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
             result.append(hdu_new)
             ext_new = ext + n_exts
             result[ext_new].header['EXTNAME'] = result[ext].header['EXTNAME'][0:4] + 'DIST'  # change extension name
-            _log.debug('Appending new extension {} with EXTNAME = {}'.format(ext_new, result[ext_new].header['EXTNAME']))
+            _log.info('Appending new extension {} with EXTNAME = {}'.format(ext_new, result[ext_new].header['EXTNAME']))
 
         # apply detector charge transfer model
+        _log.info('WFI: Adding charge diffusion')
         psf_updated = detectors.apply_detector_charge_diffusion(result,
                                                                 options)
 
@@ -536,6 +541,16 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
 
         # Rewrite result variable based on output_mode set:
         stpsf_core.SpaceTelescopeInstrument._calc_psf_format_output(self, result, options)
+
+        add_ipc = options.get('add_ipc', True)
+        if add_ipc and ('DET_DIST' in result):
+            # apply detector IPC model (after binning to detector sampling)
+            _log.info('WFI: Adding interpixel capacitance (IPC) to DET_DIST extension')
+            result = detectors.apply_detector_ipc(result)
+        if add_ipc and ('OVERDIST' in result):
+            # apply detector IPC model to oversampled PSF
+            _log.info('WFI: Adding interpixel capacitance (IPC) to OVERDIST extension')
+            result = detectors.apply_detector_ipc(result, extname='OVERDIST')
 
 
 class WFIPupilController:

--- a/stpsf/roman.py
+++ b/stpsf/roman.py
@@ -376,7 +376,7 @@ class RomanInstrument(stpsf_core.SpaceTelescopeInstrument):
         self.options = _RomanInstrumentOptionsDict(self.options.copy())
 
         # then, set defaults for options modifiable by users
-        self.options['add_ipc'] = False
+        self.options['add_ipc'] = True
         # charge_diffusion_sigma set in RomanInstrument._calc_psf_format_output
         self.options['jitter'] = 'gaussian'
         self.options['jitter_sigma'] = constants.ROMAN_TYPICAL_LOS_JITTER_PER_AXIS


### PR DESCRIPTION
The IPC reference files are per-detector, so this implementation is more similar to NIRCam's than the MIRI-like strategy we had previously discussed of adding a WFI entry to `constants.INSTRUMENT_IPC_DEFAULT_KERNEL_PARAMETERS`.

We could avoid the need for this file by querying the information from CRDS, but I didn't implement that here since it's not currently an STPSF dependency.

I added an `ipc` directory to our `prelaunch` location with the needed extra FITS file and the script that creates it. You can also re-download my temporary Box zip file. 